### PR TITLE
Add authorization, admins, and admin/signups

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,8 @@
+ADMIN_EMAILS=admin1@restyled.io,admin2@restyled.io
 AUTH_DUMMY_LOGIN=true
 DATABASE_URL=postgres://postgres:password@localhost:5432/restyled_test
 GITHUB_APP_ID=1234
 GITHUB_APP_KEY=non-empty
+GITHUB_OAUTH_CLIENT_ID=non-empty
+GITHUB_OAUTH_CLIENT_SECRET=non-empty
 LOG_LEVEL=ERROR

--- a/.weeder.yaml
+++ b/.weeder.yaml
@@ -1,6 +1,8 @@
 - package:
   - name: jwt
 - package:
+  - name: yesod-auth-oauth2
+- package:
   - name: restyled
   - section:
     - name: exe:restyled.io

--- a/config/models
+++ b/config/models
@@ -1,2 +1,11 @@
 Signup
   email Text
+
+User
+  email Text
+
+  credsIdent Text
+  credsPlugin Text
+
+  UniqueUser credsPlugin credsIdent
+  deriving Eq Show

--- a/config/routes
+++ b/config/routes
@@ -1,3 +1,4 @@
+/auth AuthR Auth getAuth
 /favicon.ico FaviconR GET
 /revision RevisionR GET
 /robots.txt RobotsR GET
@@ -7,3 +8,6 @@
 /docs DocsR GET
 /signups SignupR POST
 /webhooks WebhooksR POST
+
+/admin AdminP:
+  /signups      AdminSignupsR GET

--- a/package.yaml
+++ b/package.yaml
@@ -44,6 +44,8 @@ library:
   - wai-logger
   - warp
   - yesod
+  - yesod-auth
+  - yesod-auth-oauth2
   - yesod-core
   - yesod-form
   - yesod-static

--- a/src/Application.hs
+++ b/src/Application.hs
@@ -51,12 +51,15 @@ import Network.Wai.Middleware.RequestLogger
     , outputFormat
     )
 import System.Log.FastLogger (defaultBufSize, newStdoutLoggerSet, toLogStr)
+import Yesod.Auth
 
 import Handler.Common
 import Handler.Docs
 import Handler.Home
 import Handler.Signup
 import Handler.Webhooks
+
+import Handler.Admin.Signups
 
 mkYesodDispatch "App" resourcesApp
 

--- a/src/Handler/Admin/Signups.hs
+++ b/src/Handler/Admin/Signups.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Handler.Admin.Signups where
+
+import Import
+
+getAdminSignupsR :: Handler Html
+getAdminSignupsR = do
+    signups <- runDB $ selectList [] []
+
+    defaultLayout $ do
+        setTitle "Admin - Signups"
+        $(widgetFile "admin/signups")

--- a/src/Yesod/Auth/OAuth2/GithubApp.hs
+++ b/src/Yesod/Auth/OAuth2/GithubApp.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Yesod.Auth.OAuth2.GithubApp
+    ( oauth2GithubApp
+    , module Yesod.Auth.OAuth2
+    ) where
+
+import Control.Exception (throwIO)
+import Data.Text (Text)
+import GitHub.Data (User(..), untagId)
+import Yesod.Auth
+import Yesod.Auth.OAuth2
+import qualified Data.Text as T
+
+oauth2GithubApp
+    :: YesodAuth m
+    => Text -- ^ Client ID
+    -> Text -- ^ Client Secret
+    -> AuthPlugin m
+oauth2GithubApp clientId clientSecret = authOAuth2
+    "github"
+    OAuth2
+        { oauthClientId = clientId
+        , oauthClientSecret = clientSecret
+        , oauthOAuthorizeEndpoint = "https://github.com/login/oauth/authorize"
+        , oauthAccessTokenEndpoint = "https://github.com/login/oauth/access_token"
+        , oauthCallback = Nothing
+        }
+    (\m t -> do
+        euser <- authGetJSON m (accessToken t) "https://api.github.com/user"
+
+        case euser of
+            Left err -> throwIO $ invalidProfileResponse "github" err
+            Right user -> return Creds
+                { credsPlugin = "github"
+                , credsIdent = T.pack $ show $ untagId $ userId user
+                , credsExtra = maybe [] (\e -> [("email", e)]) $ userEmail user
+                }
+    )

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,9 @@
 resolver: lts-9.5
 packages:
-  - "."
+- location: .
+- location:
+    git: https://github.com/thoughtbot/yesod-auth-oauth2
+    commit: 937ad572a31dcbb2d5fe75b91f689c7a2f6ecfca
+  extra-dep: true
 extra-deps:
 - load-env-0.1.1

--- a/templates/admin/signups.hamlet
+++ b/templates/admin/signups.hamlet
@@ -1,0 +1,7 @@
+<main>
+  <h1>Admin/Signups
+
+<section>
+  <ul>
+    $forall Entity _ s <- signups
+      <li>#{signupEmail s}

--- a/templates/default-layout.hamlet
+++ b/templates/default-layout.hamlet
@@ -6,6 +6,13 @@
     <ul>
       <li>
         <a href=@{DocsR}>Documentation
+      $maybe Entity _ user <- muser
+        <li>
+          <abbr title="Log out">
+            <a href=@{AuthR LogoutR}>#{userEmail user}
+      $nothing
+        <li .button--github>
+          <a href=@{AuthR $ oauth2Url "github"}>Login
 
 $maybe msg <- mmsg
   <aside #message .info>

--- a/test/Handler/AdminSpec.hs
+++ b/test/Handler/AdminSpec.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Handler.AdminSpec (spec) where
+
+import TestImport
+
+spec :: Spec
+spec = withApp $ do
+    describe "AdminP" $ do
+        it "turns away un-authenticated users" $ do
+            get $ AdminP AdminSignupsR
+
+            statusIs 403
+
+        it "turns away un-authorized users" $ do
+            let user = User
+                    { userEmail = "normie@restyled.io"
+                    , userCredsIdent = "1"
+                    , userCredsPlugin = "dummy"
+                    }
+            entity <- runDB $ insertEntity user
+            authenticateAs entity
+
+            get $ AdminP AdminSignupsR
+
+            statusIs 403
+
+        -- N.B. .env.test is known to have an admin1 and admin2
+        it "allows authorized users" $ do
+            let user1 = User
+                    { userEmail = "admin1@restyled.io"
+                    , userCredsIdent = "1"
+                    , userCredsPlugin = "dummy"
+                    }
+                user2 = User
+                    { userEmail = "admin2@restyled.io"
+                    , userCredsIdent = "2"
+                    , userCredsPlugin = "dummy"
+                    }
+            entity1 <- runDB $ insertEntity user1
+            entity2 <- runDB $ insertEntity user2
+
+            authenticateAs entity1
+            get $ AdminP AdminSignupsR
+            statusIs 200
+
+            authenticateAs entity2
+            get $ AdminP AdminSignupsR
+            statusIs 200

--- a/test/TestImport.hs
+++ b/test/TestImport.hs
@@ -4,6 +4,7 @@
 module TestImport
     ( runDB
     , withApp
+    , authenticateAs
     , module X
     ) where
 
@@ -14,7 +15,7 @@ import Database.Persist.Sql  (SqlPersistM, SqlBackend, runSqlPersistMPool, rawEx
 import Foundation            as X
 import LoadEnv               (loadEnvFrom)
 import Model                 as X
-import Settings              (loadEnvSettings)
+import Settings              (AppSettings(..), loadEnvSettings)
 import Test.Hspec.Lifted     as X
 import Text.Shakespeare.Text (st)
 import Yesod.Test            as X
@@ -57,3 +58,12 @@ getTables = do
     |] []
 
     return $ map unSingle tables
+
+authenticateAs :: Entity User -> YesodExample App ()
+authenticateAs (Entity _ u) = do
+    testRoot <- fmap (appRoot . appSettings) getTestYesod
+
+    request $ do
+        setMethod "POST"
+        addPostParam "ident" $ userCredsIdent u
+        setUrl $ testRoot ++ "/auth/page/dummy"


### PR DESCRIPTION
Now that our database is correctly fire-walled, I need an in-app way to
interact with the data we store, which is currently just signups.

A simple admin/signups page will do, but still required some way to
identify myself as an admin, which required proper authentication with
GitHub, which required updated yesod-auth-oauth2, and turned out to
still need a custom GitHubApps-specific plugin.