### PR TITLE
Authorize private repo pages for real

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,12 @@ jobs:
             - stack-
       - run:
           name: Dependencies
-          command: make setup
+          command: |
+            make setup
+            curl "$HLINT_YAML_SRC" > .hlint.yaml
+          environment:
+            # yamllint disable-line rule:line-length
+            HLINT_YAML_SRC: https://raw.githubusercontent.com/pbrisbin/dotfiles/master/hlint.yaml
       - run:
           name: Build
           command: make build

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,9 +1,0 @@
-- ignore:
-    name: Use newtype instead of data
-    within: Repository
-- ignore:
-    name: Reduce duplication
-    within: Application
-- ignore:
-    name: Redundant do
-    within: spec

--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -1,0 +1,17 @@
+---
+remote_files:
+  # yamllint disable-line rule:line-length
+  - url: https://raw.githubusercontent.com/pbrisbin/dotfiles/master/config/brittany/config.yaml
+    path: brittany.yaml
+restylers:
+  - stylish-haskell
+  - brittany:
+      include:
+        - "**/*.hs"
+
+        # CPP, HsSpliceE, etc
+        - "!src/Application.hs"
+        - "!src/Settings.hs"
+        - "!src/Widgets/Job.hs"
+        - "!src/Widgets/Repo.hs"
+        - "!test/TestImport.hs"

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ db.seed:
 	PGPASSWORD=password psql --user postgres --host localhost restyled < seeds.sql
 
 .PHONY: db.reset
-db.reset: db.drop db.create db.seed
+db.reset: db.drop db.create
 
 .PHONY: setup
 setup:

--- a/config/models
+++ b/config/models
@@ -4,6 +4,11 @@ Signup
 User
   email Text
 
+  -- For some reason persistent wanted to migrate this as var char, which it
+  -- didn't do for any of the other `Id a` fields... :shrug:
+  githubUserId (Id User) Maybe sqltype=integer
+  githubUsername (Name User) Maybe
+
   credsIdent Text
   credsPlugin Text
 

--- a/config/routes
+++ b/config/routes
@@ -9,19 +9,15 @@
 /webhooks WebhooksR POST
 /privacy-policy PrivacyPolicyR GET
 
-/gh/#OwnerName OwnerP:
-  /repos ReposP:
-    / ReposR GET
-    /#RepoName RepoP:
-      / RepoR GET
-      /pulls RepoPullsP:
-        /#Int RepoPullP:
-          / RepoPullR GET
-          /jobs RepoPullJobsP:
-            / RepoPullJobsR GET
-      /jobs RepoJobsP:
-        / RepoJobsR GET
-        /#JobId RepoJobR GET
+/gh/#OwnerName/repos/#RepoName RepoP:
+  / RepoR GET
+  /pulls/#Int RepoPullP:
+    / RepoPullR GET
+    /jobs RepoPullJobsP:
+      / RepoPullJobsR GET
+  /jobs RepoJobsP:
+    / RepoJobsR GET
+    /#JobId RepoJobR GET
 
 /admin AdminR GET
 /admin AdminP:

--- a/package.yaml
+++ b/package.yaml
@@ -15,6 +15,7 @@ ghc-options: -Wall
 library:
   dependencies:
     - aeson
+    - aeson-casing
     - blaze-markup
     - bytestring
     - case-insensitive

--- a/package.yaml
+++ b/package.yaml
@@ -18,7 +18,6 @@ library:
     - aeson-casing
     - blaze-markup
     - bytestring
-    - case-insensitive
     - classy-prelude
     - classy-prelude-yesod
     - conduit

--- a/package.yaml
+++ b/package.yaml
@@ -24,6 +24,7 @@ library:
     - conduit
     - containers
     - envparse
+    - errors
     - fast-logger
     - file-embed
     - formatting
@@ -38,6 +39,7 @@ library:
     - jwt
     - load-env
     - monad-logger
+    - mtl
     - persistent
     - persistent-postgresql
     - persistent-template

--- a/seeds.sql
+++ b/seeds.sql
@@ -34,6 +34,12 @@ INSERT INTO repo (
   58920,
   FALSE,
   TRUE
+), (
+  'pbrisbin',
+  'load-env',
+  58920,
+  TRUE,
+  TRUE
 );
 
 DELETE FROM job;

--- a/src/Authentication.hs
+++ b/src/Authentication.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Authentication
+    ( authenticateUser
+    ) where
+
+import Import.NoFoundation
+
+import Data.Aeson
+import Data.Aeson.Casing
+import GitHub.Data (Id, Name)
+import Yesod.Auth
+import Yesod.Auth.Message
+import Yesod.Auth.OAuth2
+
+data GitHubUser = GitHubUser
+    { ghuEmail :: Text
+    , ghuId :: Id User
+    , ghuLogin :: Name User
+    }
+    deriving (Eq, Show, Generic)
+
+instance FromJSON GitHubUser where
+    parseJSON = genericParseJSON $ aesonPrefix snakeCase
+
+authenticateUser
+    :: AuthId site ~ UserId => Creds site -> DB (AuthenticationResult site)
+authenticateUser creds@Creds {..} = do
+    mUserId <- entityKey <$$> getBy (UniqueUser credsPlugin credsIdent)
+    logDebugN $ "Existing User Id: " <> tshow mUserId
+
+    let eGhUser = getUserResponseJSON creds
+    logDebugN $ "GitHub user: " <> tshow eGhUser
+
+    case (mUserId, eGhUser) of
+        (Nothing, Left err) -> do
+            logWarnN $ "Error parsing user response: " <> pack err
+            pure $ UserError $ IdentifierNotFound "GitHub OAuth2 response"
+
+        (Nothing, Right ghUser) -> createFromGitHub creds ghUser
+        (Just userId, Right ghUser) -> updateFromGitHub creds userId ghUser
+
+        -- Probably testing via auth/dummy, just authenticate
+        (Just userId, Left _) -> pure $ Authenticated userId
+
+createFromGitHub
+    :: AuthId site ~ UserId
+    => Creds site
+    -> GitHubUser
+    -> DB (AuthenticationResult site)
+createFromGitHub Creds {..} GitHubUser {..} = Authenticated <$> insert User
+    { userEmail = ghuEmail
+    , userGithubUserId = Just ghuId
+    , userGithubUsername = Just ghuLogin
+    , userCredsIdent = credsIdent
+    , userCredsPlugin = credsPlugin
+    }
+
+updateFromGitHub
+    :: AuthId site ~ UserId
+    => Creds site
+    -> UserId
+    -> GitHubUser
+    -> DB (AuthenticationResult site)
+updateFromGitHub Creds {..} userId GitHubUser {..} =
+    Authenticated userId <$ updateWhere
+        [ UserId ==. userId
+        , UserCredsIdent ==. credsIdent
+        , UserCredsPlugin ==. credsPlugin
+        ]
+        [ UserEmail =. ghuEmail
+        , UserGithubUserId =. Just ghuId
+        , UserGithubUsername =. Just ghuLogin
+        ]

--- a/src/Authorization.hs
+++ b/src/Authorization.hs
@@ -1,15 +1,11 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Authorization
     ( authorizeAdmin
     , authorizeRepo
-
-    -- * Deprecated
-    , requireRepositoriesAccess
     ) where
 
 import Import.NoFoundation
@@ -69,10 +65,3 @@ authorizeRepo settings owner name (Just userId) = do
 authorizeWhen :: MonadHandler m => Bool -> m AuthResult
 authorizeWhen True = pure Authorized
 authorizeWhen False = notFound
-
--- | Run @'requirePublic'@ on all @'Repo'@s in the list
-requireRepositoriesAccess :: [Entity Repo] -> DB ()
-requireRepositoriesAccess = traverse_ $ requirePublic . entityVal
-  where
-    requirePublic Repo {..} | repoIsPrivate = notFound
-    requirePublic _ = pure ()

--- a/src/Authorization.hs
+++ b/src/Authorization.hs
@@ -52,11 +52,7 @@ authorizeRepo settings owner name (Just userId) = do
     if repoIsPrivate repo
         then do
             user <- get404 userId
-            canRead <- collaboratorCanRead
-                (appGitHubAppId settings)
-                (appGitHubAppKey settings)
-                repo
-                user
+            canRead <- collaboratorCanRead settings repo user
             logDebugN $ "User: " <> tshow user
             logDebugN $ "Can-Read: " <> tshow canRead
             authorizeWhen canRead

--- a/src/Authorization.hs
+++ b/src/Authorization.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -6,11 +7,16 @@
 module Authorization
     ( requireRepositoryAccess
     , requireRepositoriesAccess
+    , authorizeAdmin
+    , authorizeRepo
     ) where
 
-import Import
+import Import.NoFoundation
 
 import Database.Persist.Sql (SqlReadT)
+import GitHub.Data (Name, toPathPart)
+import qualified GitHub.Data as GH
+import Model.Collaborator
 
 -- | Require the current user has access to the given @'Repo'@
 --
@@ -18,9 +24,61 @@ import Database.Persist.Sql (SqlReadT)
 -- GitHub permissions, granting read to admins, etc.
 --
 requireRepositoryAccess :: MonadHandler m => Repo -> SqlReadT m ()
-requireRepositoryAccess Repo{..} | not repoIsPrivate = pure ()
+requireRepositoryAccess Repo {..} | not repoIsPrivate = pure ()
 requireRepositoryAccess _ = notFound -- Don't leak existence
 
 -- | Run @'requireRepositoryAccess'@ on all @'Repo'@s in the list
 requireRepositoriesAccess :: MonadHandler m => [Entity Repo] -> SqlReadT m ()
 requireRepositoriesAccess = traverse_ $ requireRepositoryAccess . entityVal
+
+authorizeAdmin :: AppSettings -> Maybe UserId -> DB AuthResult
+authorizeAdmin _ Nothing = notFound
+authorizeAdmin settings (Just userId) = do
+    user <- fromMaybeM notFound =<< get userId
+    authorizeWhen $ userEmail user `elem` appAdmins settings
+
+authorizeRepo
+    :: AppSettings
+    -> Name GH.Owner
+    -> Name GH.Repo
+    -> Maybe UserId
+    -> DB AuthResult
+authorizeRepo _ owner name Nothing = do
+    Entity _ repo <- getBy404 $ UniqueRepo owner name
+
+    logDebugN
+        $ "Authorizing "
+        <> toPathPart owner
+        <> "/"
+        <> toPathPart name
+        <> " for anonymous user"
+
+    authorizeWhen $ not $ repoIsPrivate repo
+
+authorizeRepo settings owner name (Just userId) = do
+    Entity _ repo <- getBy404 $ UniqueRepo owner name
+
+    logDebugN
+        $ "Authorizing "
+        <> toPathPart owner
+        <> "/"
+        <> toPathPart name
+        <> " for authenticated UserId: "
+        <> tshow userId
+
+    if repoIsPrivate repo
+        then do
+            user <- get404 userId
+            canRead <- collaboratorCanRead
+                (appGitHubAppId settings)
+                (appGitHubAppKey settings)
+                repo
+                user
+            logDebugN $ "User: " <> tshow user
+            logDebugN $ "Can-Read: " <> tshow canRead
+            authorizeWhen canRead
+        else pure Authorized
+
+authorizeWhen :: MonadHandler m => Bool -> m AuthResult
+authorizeWhen True = pure Authorized
+authorizeWhen False = notFound

--- a/src/Foundation.hs
+++ b/src/Foundation.hs
@@ -94,14 +94,9 @@ instance Yesod App where
         settings <- getsYesod appSettings
         runDB $ authorizeAdmin settings =<< maybeAuthId
 
-    -- TODO: remove this route or implement authorization here. It currently
-    -- uses the old "is-public" logic within the Handler itself.
-    isAuthorized (OwnerP _ (ReposP ReposR)) _ = pure Authorized
-
-    isAuthorized (OwnerP owner (ReposP (RepoP repo _))) _ = do
+    isAuthorized (RepoP owner repo _) _ = do
         settings <- getsYesod appSettings
         runDB $ authorizeRepo settings owner repo =<< maybeAuthId
-
 
     addStaticContent = addStaticContentExternal
         minifym

--- a/src/Foundation.hs
+++ b/src/Foundation.hs
@@ -49,8 +49,6 @@ instance Yesod App where
         -- 2 week session timeout
         <$> envClientSessionBackend (60 * 24 * 14) "SESSION_KEY"
 
-    yesodMiddleware = defaultYesodMiddleware
-
     defaultLayout widget = do
         master <- getYesod
         mmsg <- getMessage

--- a/src/Foundation.hs
+++ b/src/Foundation.hs
@@ -97,6 +97,16 @@ instance Yesod App where
 
     defaultMessageWidget title body = $(widgetFile "default-message-widget")
 
+    errorHandler NotFound = do
+        mUserId <- maybeAuthId
+        html <- defaultLayout $ do
+            setTitle "Not Found"
+            $(widgetFile "not-found")
+
+        pure $ TypedContent typeHtml $ toContent html
+
+    errorHandler x = defaultErrorHandler x
+
 -- | Just like default-layout, but admin-specific nav and CSS
 adminLayout :: Widget -> Handler Html
 adminLayout widget = do

--- a/src/Foundation.hs
+++ b/src/Foundation.hs
@@ -52,6 +52,7 @@ instance Yesod App where
     defaultLayout widget = do
         master <- getYesod
         mmsg <- getMessage
+        mUserId <- maybeAuthId
         pc <- widgetToPageContent $ do
             addStylesheet $ StaticR css_strapless_css
             addStylesheet $ StaticR css_main_css
@@ -101,6 +102,7 @@ adminLayout :: Widget -> Handler Html
 adminLayout widget = do
     master <- getYesod
     mmsg <- getMessage
+    mUserId <- maybeAuthId
     pc <- widgetToPageContent $ do
         addStylesheet $ StaticR css_strapless_css
         addStylesheet $ StaticR css_main_css

--- a/src/Foundation.hs
+++ b/src/Foundation.hs
@@ -14,12 +14,12 @@ where
 
 import Import.NoFoundation
 
+import Authorization
 import Data.Aeson
 import Data.Aeson.Casing
 import Database.Persist.Sql (ConnectionPool, runSqlPool)
 import Database.Redis (Connection)
 import GitHub.Data (Id, Name)
-import qualified GitHub.Data as GH
 import GitHub.Instances (OwnerName, RepoName)
 import Text.Hamlet (hamletFile)
 import Text.Jasmine (minifym)
@@ -76,8 +76,18 @@ instance Yesod App where
 
     authRoute _ = Just $ AuthR $ oauth2Url "github"
 
-    isAuthorized AdminR _ = authorizeAdmins
-    isAuthorized (AdminP _) _ = authorizeAdmins
+    isAuthorized AdminR _ = do
+        settings <- getsYesod appSettings
+        runDB $ authorizeAdmin settings =<< maybeAuthId
+
+    isAuthorized (AdminP _) _ = do
+        settings <- getsYesod appSettings
+        runDB $ authorizeAdmin settings =<< maybeAuthId
+
+    isAuthorized (OwnerP owner (ReposP (RepoP repo _))) _ = do
+        settings <- getsYesod appSettings
+        runDB $ authorizeRepo settings owner repo =<< maybeAuthId
+
     isAuthorized _ _ = return Authorized
 
     addStaticContent = addStaticContentExternal
@@ -105,17 +115,6 @@ adminLayout widget = do
         addStylesheet $ StaticR css_admin_css
         $(widgetFile "admin-layout")
     withUrlRenderer $(hamletFile "templates/default-layout-wrapper.hamlet")
-
-authorizeAdmins :: Handler AuthResult
-authorizeAdmins = do
-    admins <- appAdmins <$> getsYesod appSettings
-    authorizeAdmin <$> maybeAuth <*> pure admins
-
-authorizeAdmin :: Maybe (Entity User) -> [Text] -> AuthResult
-authorizeAdmin Nothing _ = AuthenticationRequired
-authorizeAdmin (Just (Entity _ u)) admins
-    | userEmail u `elem` admins = Authorized
-    | otherwise = Unauthorized "Unauthorized"
 
 instance YesodAuth App where
     type AuthId App = UserId

--- a/src/Foundation.hs
+++ b/src/Foundation.hs
@@ -14,8 +14,6 @@ where
 import Import.NoFoundation
 
 import Data.Aeson
-import qualified Data.CaseInsensitive as CI
-import qualified Data.Text.Encoding as TE
 import Database.Persist.Sql (ConnectionPool, runSqlPool)
 import Database.Redis (Connection)
 import GitHub.Instances (OwnerName, RepoName)

--- a/src/Foundation.hs
+++ b/src/Foundation.hs
@@ -76,6 +76,16 @@ instance Yesod App where
 
     authRoute _ = Just $ AuthR $ oauth2Url "github"
 
+    isAuthorized (AuthR _) _ = pure Authorized
+    isAuthorized (StaticR _) _ = pure Authorized
+    isAuthorized FaviconR _ = pure Authorized
+    isAuthorized WebhooksR _ = pure Authorized
+    isAuthorized PrivacyPolicyR _ = pure Authorized
+    isAuthorized HomeR _ = pure Authorized
+    isAuthorized RevisionR _ = pure Authorized
+    isAuthorized RobotsR _ = pure Authorized
+    isAuthorized SignupR _ = pure Authorized
+
     isAuthorized AdminR _ = do
         settings <- getsYesod appSettings
         runDB $ authorizeAdmin settings =<< maybeAuthId
@@ -84,11 +94,14 @@ instance Yesod App where
         settings <- getsYesod appSettings
         runDB $ authorizeAdmin settings =<< maybeAuthId
 
+    -- TODO: remove this route or implement authorization here. It currently
+    -- uses the old "is-public" logic within the Handler itself.
+    isAuthorized (OwnerP _ (ReposP ReposR)) _ = pure Authorized
+
     isAuthorized (OwnerP owner (ReposP (RepoP repo _))) _ = do
         settings <- getsYesod appSettings
         runDB $ authorizeRepo settings owner repo =<< maybeAuthId
 
-    isAuthorized _ _ = return Authorized
 
     addStaticContent = addStaticContentExternal
         minifym

--- a/src/Handler/Repos.hs
+++ b/src/Handler/Repos.hs
@@ -3,8 +3,7 @@
 {-# LANGUAGE TupleSections #-}
 
 module Handler.Repos
-    ( getReposR
-    , getRepoR
+    ( getRepoR
     , getRepoPullR
     , getRepoPullJobsR
     , getRepoJobsR
@@ -14,27 +13,9 @@ where
 
 import Import
 
-import Authorization
 import GitHub.Data hiding (Repo(..))
 import qualified GitHub.Data as GH
 import Widgets.Job
-import Widgets.Repo
-
-getReposR :: Name Owner -> Handler Html
-getReposR owner = do
-    reposWithStats <- runDB $ do
-        repos <- selectList
-            [RepoOwner ==. owner]
-            [Asc RepoName, LimitTo repositoriesListLimit]
-
-        requireRepositoriesAccess repos
-        traverse repoWithStats repos
-
-    when (null reposWithStats) notFound
-
-    defaultLayout $ do
-        setTitle $ toHtml $ toPathPart owner <> " repositories"
-        $(widgetFile "repos")
 
 getRepoR :: Name Owner -> Name GH.Repo -> Handler Html
 getRepoR = getRepoJobsR
@@ -90,6 +71,3 @@ getRepoJobR owner name jobId = do
             <> " #"
             <> toPathPiece jobId
         $(widgetFile "job")
-
-repositoriesListLimit :: Int
-repositoriesListLimit = 50

--- a/src/Handler/Repos.hs
+++ b/src/Handler/Repos.hs
@@ -44,16 +44,12 @@ getRepoPullR = getRepoPullJobsR
 
 getRepoPullJobsR :: Name Owner -> Name GH.Repo -> Int -> Handler Html
 getRepoPullJobsR owner name num = do
-    jobs <- runDB $ do
-        Entity _ repo <- getBy404 $ UniqueRepo owner name
-        requireRepositoryAccess repo
-
-        selectList
-            [ JobOwner ==. repoOwner repo
-            , JobRepo ==. repoName repo
-            , JobPullRequest ==. mkId Proxy num
-            ]
-            [Desc JobCompletedAt, Desc JobCreatedAt]
+    jobs <- runDB $ selectList
+        [ JobOwner ==. owner
+        , JobRepo ==. name
+        , JobPullRequest ==. mkId Proxy num
+        ]
+        [Desc JobCompletedAt, Desc JobCreatedAt]
 
     defaultLayout $ do
         setTitle
@@ -68,13 +64,9 @@ getRepoPullJobsR owner name num = do
 
 getRepoJobsR :: Name Owner -> Name GH.Repo -> Handler Html
 getRepoJobsR owner name = do
-    jobs <- runDB $ do
-        Entity _ repo <- getBy404 $ UniqueRepo owner name
-        requireRepositoryAccess repo
-
-        selectList
-            [JobOwner ==. repoOwner repo, JobRepo ==. repoName repo]
-            [Desc JobCompletedAt, Desc JobCreatedAt]
+    jobs <- runDB $ selectList
+        [JobOwner ==. owner, JobRepo ==. name]
+        [Desc JobCompletedAt, Desc JobCreatedAt]
 
     defaultLayout $ do
         setTitle
@@ -87,10 +79,7 @@ getRepoJobsR owner name = do
 
 getRepoJobR :: Name Owner -> Name GH.Repo -> JobId -> Handler Html
 getRepoJobR owner name jobId = do
-    job <- runDB $ do
-        Entity _ repo <- getBy404 $ UniqueRepo owner name
-        requireRepositoryAccess repo
-        fromMaybeM notFound =<< getEntity jobId
+    job <- runDB $ fromMaybeM notFound =<< getEntity jobId
 
     defaultLayout $ do
         setTitle

--- a/src/Model.hs
+++ b/src/Model.hs
@@ -25,7 +25,7 @@ import GitHub.Data.Apps (Installation)
 import GitHub.Instances ()
 
 type DB a = forall backend m.
-    (backend ~ SqlBackend, MonadIO m) => ReaderT backend m a
+    (backend ~ SqlBackend, MonadHandler m) => ReaderT backend m a
 
 share [mkPersist sqlSettings, mkMigrate "migrateAll"]
     $(persistFileWith lowerCaseSettings "config/models")

--- a/src/Model/Collaborator.hs
+++ b/src/Model/Collaborator.hs
@@ -1,0 +1,102 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Model.Collaborator
+    ( collaboratorCanRead
+    ) where
+
+import Import.NoFoundation hiding (httpLbs)
+
+import Control.Error.Util (note)
+import Control.Monad.Except
+import Data.Aeson
+import Data.Aeson.Casing
+import qualified Data.ByteString.Lazy as BL
+import GitHub.Data (Id, toPathPart)
+import GitHub.Endpoints.Installations (AccessToken(..), App, createAccessToken)
+import Network.HTTP.Simple
+
+data RepoPermission
+    = AdminPermission
+    | ReadPermission
+    | WritePermission
+    | NonePermission
+
+instance FromJSON RepoPermission where
+    parseJSON = withText "permission" $ \case
+        "admin" -> pure AdminPermission
+        "read" -> pure ReadPermission
+        "write" -> pure WritePermission
+        "none" -> pure NonePermission
+        x -> fail $ "Invalid permissions value " <> unpack x
+
+canRead :: RepoPermission -> Bool
+canRead AdminPermission = True
+canRead ReadPermission = True
+canRead WritePermission = True
+canRead NonePermission = False
+
+newtype CollaboratorPermissions = CollaboratorPermissions
+    { cpPermission :: RepoPermission
+    }
+    deriving Generic
+
+instance FromJSON CollaboratorPermissions where
+    parseJSON = genericParseJSON $ aesonPrefix snakeCase
+
+collaboratorCanRead
+    :: (MonadIO m, MonadLogger m) => Id App -> Text -> Repo -> User -> m Bool
+collaboratorCanRead appId pem Repo {..} User {..} = do
+    result <- runExceptT $ do
+        username <- liftEither $ note "No GitHub username" userGithubUsername
+        token <- exceptIO $ createAccessToken appId pem repoInstallationId
+
+        request <-
+            githubRequest token
+            $ "/repos/"
+            <> unpack (toPathPart repoOwner)
+            <> "/"
+            <> unpack (toPathPart repoName)
+            <> "/collaborators/"
+            <> unpack (toPathPart username)
+            <> "/permission"
+
+        response <- withExceptT show $ exceptIO $ tryIO $ httpLbs request
+        permission <- decodeResponse response
+        pure $ canRead $ cpPermission permission
+    either err pure result
+  where
+    err e = logWarnN ("Error authorizing repository:\n" <> pack e) $> False
+
+githubRequest :: Monad m => AccessToken -> String -> ExceptT String m Request
+githubRequest token requestPath = do
+    request <-
+        withExceptT show
+        $ liftEither
+        $ parseRequest
+        $ "http://api.github.com"
+        <> requestPath
+
+    pure $ setRequestHeaders
+        [ ("Accept", "application/vnd.github.hellcat-preview+json")
+        , ("Authorization", "token " <> encodeUtf8 (atToken token))
+        , ("User-Agent", "Restyled.io")
+        ]
+        request
+
+decodeResponse
+    :: (FromJSON a, Monad m) => Response BL.ByteString -> ExceptT String m a
+decodeResponse response =
+    withExceptT toErrorMessage $ liftEither $ eitherDecode body
+  where
+    body = responseBody response
+    toErrorMessage msg = unlines
+        [ "Error decoding JSON response body"
+        , "Message: " <> msg
+        , "Body: " <> show body
+        ]
+
+exceptIO :: MonadIO m => IO (Either e a) -> ExceptT e m a
+exceptIO = ExceptT . liftIO

--- a/src/Routes.hs
+++ b/src/Routes.hs
@@ -2,9 +2,7 @@
 module Routes
     (
     -- * Repos
-      reposP
-    , reposR
-    , repoP
+      repoP
     , repoR
 
     -- * Repos' Pulls
@@ -31,20 +29,14 @@ import Import.NoFoundation
 import Foundation
 import qualified GitHub.Data as GH
 
-reposP :: GH.Name GH.Owner -> ReposP -> Route App
-reposP owner = OwnerP owner . ReposP
-
-reposR :: GH.Name GH.Owner -> Route App
-reposR owner = reposP owner ReposR
-
 repoP :: GH.Name GH.Owner -> GH.Name GH.Repo -> RepoP -> Route App
-repoP owner name = reposP owner . RepoP name
+repoP = RepoP
 
 repoR :: GH.Name GH.Owner -> GH.Name GH.Repo -> Route App
 repoR owner name = repoP owner name RepoR
 
 pullP :: GH.Id GH.PullRequest -> RepoPullP -> RepoP
-pullP num = RepoPullsP . RepoPullP (GH.untagId num)
+pullP = RepoPullP . GH.untagId
 
 pullR :: GH.Id GH.PullRequest -> RepoP
 pullR num = pullP num RepoPullR

--- a/src/Settings.hs
+++ b/src/Settings.hs
@@ -121,7 +121,14 @@ envSettings = AppSettings
     <*> Env.var Env.str "RESTYLER_IMAGE" (Env.def "restyled/restyler")
     <*> optional (Env.var Env.str "RESTYLER_TAG" mempty)
     <*> (map T.strip . T.splitOn "," <$> Env.var Env.str "ADMIN_EMAILS" (Env.def ""))
+#if DOCKERIZED
+    -- Don't even look for this setting if building the deployment image. We
+    -- would need to both forget the compilation flag and accidentally set the
+    -- ENV switch on production. Defense in depth.
+    <*> pure False
+#else
     <*> Env.switch "AUTH_DUMMY_LOGIN" mempty
+#endif
 
 envDatabaseConfig :: EnvParser PostgresConf
 envDatabaseConfig = PostgresConf

--- a/src/Widgets/Repo.hs
+++ b/src/Widgets/Repo.hs
@@ -4,8 +4,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 
 module Widgets.Repo
-    ( repoCard
-    , adminRepoCard
+    ( adminRepoCard
     )
 where
 
@@ -16,19 +15,6 @@ import Formatting (format, (%))
 import Formatting.Formatters (int, plural)
 import Formatting.Time (diff)
 import Widgets.Job
-
-repoCard :: RepoWithStats -> Widget
-repoCard RepoWithStats{..} = do
-    now <- liftIO getCurrentTime
-
-    let
-        jobsRoute :: Entity Repo -> Route App
-        jobsRoute (Entity _ Repo {..}) = repoP repoOwner repoName jobsR
-
-        mAction :: Maybe Widget
-        mAction = Nothing
-
-    $(widgetFile "widgets/repo-card")
 
 adminRepoCard :: RepoWithStats -> Widget
 adminRepoCard RepoWithStats{..} = do

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -27,6 +27,10 @@ form .errors {
   font-weight: bold;
 }
 
+.centered {
+  text-align: center;
+}
+
 .how-it-works-highlight {
   background: #f0ebee;
   border-radius: 3px;

--- a/templates/admin-layout.hamlet
+++ b/templates/admin-layout.hamlet
@@ -7,6 +7,9 @@
         <a href=@{AdminP $ AdminJobsP AdminJobsNewR}>New Job
       <li>
         <a href=@{AdminP AdminSignupsR}>Signups
+      $maybe _ <- mUserId
+        <li>
+          <a href=@{AuthR $ LogoutR}>Log out
 
 $maybe msg <- mmsg
   <aside #message .info>

--- a/templates/default-layout-wrapper.hamlet
+++ b/templates/default-layout-wrapper.hamlet
@@ -7,30 +7,8 @@ $newline always
     <meta name="description" content="">
     <meta name="author" content="">
     <meta name="viewport" content="width=device-width,initial-scale=1">
-
-    ^{pageHead pc}
-
     <link rel="shortcut icon" href="/favicon.ico" />
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.13/css/all.css" integrity="sha384-DNOHZ68U8hZfKXOrtjWvjxusGo9WQnrNx2sqG0tfsghAvtVlRW3tvkXWZh58N9jp" crossorigin="anonymous">
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.js">
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/2.0.3/js.cookie.min.js">
-
-    <script>
-      /* The `defaultCsrfMiddleware` Middleware added in Foundation.hs adds a CSRF token the request cookies. */
-      /* AJAX requests should add that token to a header to be validated by the server. */
-      /* See the CSRF documentation in the Yesod.Core.Handler module of the yesod-core package for details. */
-      var csrfHeaderName = "#{TE.decodeUtf8 $ CI.foldedCase defaultCsrfHeaderName}";
-
-      var csrfCookieName = "#{TE.decodeUtf8 defaultCsrfCookieName}";
-      var csrfToken = Cookies.get(csrfCookieName);
-
-
-      if (csrfToken) {
-      \  $.ajaxPrefilter(function( options, originalOptions, jqXHR ) {
-      \      if (!options.crossDomain) {
-      \          jqXHR.setRequestHeader(csrfHeaderName, csrfToken);
-      \      }
-      \  });
-      }
+    ^{pageHead pc}
   <body>
     ^{pageBody pc}

--- a/templates/default-layout.hamlet
+++ b/templates/default-layout.hamlet
@@ -6,6 +6,9 @@
     <ul>
       <li>
         <a href=https://github.com/restyled-io/restyled.io/wiki>Documentation
+      $maybe _ <- mUserId
+        <li>
+          <a href=@{AuthR $ LogoutR}>Log out
 
 $maybe msg <- mmsg
   <aside #message .info>

--- a/templates/not-found.hamlet
+++ b/templates/not-found.hamlet
@@ -1,0 +1,18 @@
+<main>
+  <h1>Not Found
+
+<section>
+  <p>
+    This page doesn't exist.
+
+$maybe _ <- mUserId
+  $# no content
+$nothing
+  <section .action>
+    <p>
+      <strong>Psst...
+      Sometimes pages are inaccessible because you aren't logged-in.
+
+    <p .centered>
+      <a .button href=@{AuthR $ oauth2Url "github"}>
+        Log in with GitHub

--- a/templates/repos.hamlet
+++ b/templates/repos.hamlet
@@ -1,6 +1,0 @@
-<section>
-  $forall repoWithStats <- reposWithStats
-      ^{repoCard repoWithStats}
-
-  <aside>
-    <em>Results limited to #{repositoriesListLimit} repositories.

--- a/templates/widgets/job-card.hamlet
+++ b/templates/widgets/job-card.hamlet
@@ -2,8 +2,7 @@ $with Entity jobId job <- job
   <div .card>
     <header>
       <a .permalink href=@{repoP (jobOwner job) (jobRepo job) $ jobR jobId}>permalink
-      <a href=@{reposR $ jobOwner job}>
-        #{toPathPart $ jobOwner job}
+      #{toPathPart $ jobOwner job}
       /
       <a href=@{repoP (jobOwner job) (jobRepo job) $ jobsR}>
         #{toPathPart $ jobRepo job}

--- a/test/Handler/AdminSpec.hs
+++ b/test/Handler/AdminSpec.hs
@@ -17,6 +17,8 @@ spec = withApp $ do
         it "turns away un-authorized users" $ do
             authenticateAsUser User
                 { userEmail = "normie@restyled.io"
+                , userGithubUserId = Nothing
+                , userGithubUsername = Nothing
                 , userCredsIdent = "1"
                 , userCredsPlugin = "dummy"
                 }
@@ -29,6 +31,8 @@ spec = withApp $ do
         it "allows only authorized users" $ do
             authenticateAsUser User
                 { userEmail = "admin1@restyled.io"
+                , userGithubUserId = Nothing
+                , userGithubUsername = Nothing
                 , userCredsIdent = "1"
                 , userCredsPlugin = "dummy"
                 }
@@ -37,6 +41,8 @@ spec = withApp $ do
 
             authenticateAsUser User
                 { userEmail = "admin2@restyled.io"
+                , userGithubUserId = Nothing
+                , userGithubUsername = Nothing
                 , userCredsIdent = "2"
                 , userCredsPlugin = "dummy"
                 }

--- a/test/Handler/AdminSpec.hs
+++ b/test/Handler/AdminSpec.hs
@@ -1,20 +1,20 @@
 {-# LANGUAGE OverloadedStrings #-}
-module Handler.AdminSpec (spec) where
+
+module Handler.AdminSpec
+    ( spec
+    ) where
 
 import TestImport
 
 spec :: Spec
 spec = withApp $ do
     describe "AdminP" $ do
-        it "directs un-authenticated users to log in" $ do
-            githubForward <- encodeUtf8 <$> authPage "/github/forward"
-
+        it "404s for un-authenticated users" $ do
             get $ AdminP AdminSignupsR
 
-            statusIs 303
-            assertHeader "Location" githubForward
+            statusIs 404
 
-        it "turns away un-authorized users" $ do
+        it "404s for un-authorized users" $ do
             authenticateAsUser User
                 { userEmail = "normie@restyled.io"
                 , userGithubUserId = Nothing
@@ -25,7 +25,7 @@ spec = withApp $ do
 
             get $ AdminP AdminSignupsR
 
-            statusIs 403
+            statusIs 404
 
         -- N.B. .env.test is known to have an admin1 and admin2
         it "allows only authorized users" $ do

--- a/test/Handler/ReposSpec.hs
+++ b/test/Handler/ReposSpec.hs
@@ -12,31 +12,6 @@ import qualified GitHub.Data as GH
 
 spec :: Spec
 spec = withApp $ do
-    describe "GET gh/:owner/repos" $ do
-        it "404s if we have no repos for that owner" $ do
-            get $ reposR "foo"
-            statusIs 404
-
-        it "200s if all repos are accessible" $ do
-            runDB $ insertMany_
-                [ publicRepo "foo" "bar"
-                , publicRepo "foo" "bat"
-                , makeInaccessible $ publicRepo "baz" "quix"
-                ]
-
-            get $ reposR "foo"
-            statusIs 200
-
-        it "404s if any repository is not accessible" $ do
-            runDB $ insertMany_
-                [ publicRepo "foo" "bar"
-                , makeInaccessible $ publicRepo "foo" "bat"
-                , makeInaccessible $ publicRepo "baz" "quix"
-                ]
-
-            get $ OwnerP "foo" $ ReposP ReposR
-            statusIs 404
-
     describe "GET gh/:owner/repos/:repo" $ do
         itRequiresRepositoryAccess RepoR
 

--- a/test/TestImport.hs
+++ b/test/TestImport.hs
@@ -12,7 +12,6 @@ module TestImport
     , authenticateAsUser
     , postForm
     , postGitHubEvent
-    , authPage
     , module X
     ) where
 


### PR DESCRIPTION
GitHub permissions are complicated. I had considered mirroring orgs and teams
on our side to accomplish authorization, but that seems like a Bad Idea.
Instead, we'll use the collaborators API endpoint we already have access to and
ask GitHub directly.

This could qualify as a timing attack, since it'll take quite a bit longer to
check if a user can access a private repo than just an outright 404. I plan to
think through this before we launch private repo support for real, and just
make it known to any free trial users that this is a caveat of the current
system.

Along the way, I cleaned up lots.

~~*History to be cleaned after CI.*~~