### PR TITLE
Move plan checking to Backend

### DIFF
--- a/config/models
+++ b/config/models
@@ -26,7 +26,7 @@ Job json
   installationId InstallationId
   owner OwnerName
   repo RepoName
-  pullRequest PullRequestId
+  pullRequest PullRequestNum
 
   createdAt UTCTime
   updatedAt UTCTime

--- a/config/models
+++ b/config/models
@@ -3,8 +3,8 @@ User
 
   -- For some reason persistent wanted to migrate this as var char, which it
   -- didn't do for any of the other `Id a` fields... :shrug:
-  githubUserId (Id User) Maybe sqltype=integer
-  githubUsername (Name User) Maybe
+  githubUserId GitHubUserId Maybe sqltype=integer
+  githubUsername GitHubUserName Maybe
 
   credsIdent Text
   credsPlugin Text
@@ -13,9 +13,9 @@ User
   deriving Eq Show
 
 Repo json
-  owner (Name Owner)
-  name (Name GH.Repo)
-  installationId (Id Installation)
+  owner OwnerName
+  name RepoName
+  installationId InstallationId
   isPrivate Bool
   debugEnabled Bool
 
@@ -23,10 +23,10 @@ Repo json
   deriving Eq Show
 
 Job json
-  installationId (Id Installation)
-  owner (Name Owner)
-  repo (Name GH.Repo)
-  pullRequest (Id PullRequest)
+  installationId InstallationId
+  owner OwnerName
+  repo RepoName
+  pullRequest PullRequestId
 
   createdAt UTCTime
   updatedAt UTCTime
@@ -40,8 +40,8 @@ Job json
 
 Plan
   type PlanType
-  owner (Name Owner)
-  repo (Name GH.Repo)
+  owner OwnerName
+  repo RepoName
 
   activeAt UTCTime Maybe
   expiresAt UTCTime Maybe

--- a/config/routes
+++ b/config/routes
@@ -10,7 +10,7 @@
 
 /gh/#OwnerName/repos/#RepoName RepoP:
   / RepoR GET
-  /pulls/#PullRequestId RepoPullP:
+  /pulls/#PullRequestNum RepoPullP:
     / RepoPullR GET
     /jobs RepoPullJobsP:
       / RepoPullJobsR GET

--- a/config/routes
+++ b/config/routes
@@ -10,7 +10,7 @@
 
 /gh/#OwnerName/repos/#RepoName RepoP:
   / RepoR GET
-  /pulls/#Int RepoPullP:
+  /pulls/#PullRequestId RepoPullP:
     / RepoPullR GET
     /jobs RepoPullJobsP:
       / RepoPullJobsR GET

--- a/package.yaml
+++ b/package.yaml
@@ -93,7 +93,6 @@ tests:
       - restyled
       - bytestring
       - classy-prelude
-      - github
       - hedis
       - hspec
       - hspec-expectations-lifted

--- a/src/Authentication.hs
+++ b/src/Authentication.hs
@@ -12,15 +12,14 @@ import Import.NoFoundation
 import Cache
 import Data.Aeson
 import Data.Aeson.Casing
-import GitHub.Data (Id, Name)
 import Yesod.Auth
 import Yesod.Auth.Message
 import Yesod.Auth.OAuth2
 
 data GitHubUser = GitHubUser
     { ghuEmail :: Text
-    , ghuId :: Id User
-    , ghuLogin :: Name User
+    , ghuId :: GitHubUserId
+    , ghuLogin :: GitHubUserName
     }
     deriving (Eq, Show, Generic)
 

--- a/src/Authorization.hs
+++ b/src/Authorization.hs
@@ -10,8 +10,6 @@ import Import.NoFoundation
 
 import Cache
 import qualified Data.Text as T
-import GitHub.Data (Name, toPathPart)
-import qualified GitHub.Data as GH
 import Model.Collaborator
 
 authorizeAdmin
@@ -24,8 +22,8 @@ authorizeAdmin settings (Just userId) = do
 authorizeRepo
     :: (MonadCache m, MonadHandler m)
     => AppSettings
-    -> Name GH.Owner
-    -> Name GH.Repo
+    -> OwnerName
+    -> RepoName
     -> Maybe UserId
     -> SqlPersistT m AuthResult
 authorizeRepo _ owner name Nothing = do
@@ -33,9 +31,9 @@ authorizeRepo _ owner name Nothing = do
 
     logDebugN
         $ "Authorizing "
-        <> toPathPart owner
+        <> toPathPiece owner
         <> "/"
-        <> toPathPart name
+        <> toPathPiece name
         <> " for anonymous user"
 
     authorizeWhen $ not $ repoIsPrivate repo
@@ -45,9 +43,9 @@ authorizeRepo settings owner name (Just userId) = do
 
     logDebugN
         $ "Authorizing "
-        <> toPathPart owner
+        <> toPathPiece owner
         <> "/"
-        <> toPathPart name
+        <> toPathPiece name
         <> " for authenticated user id="
         <> toPathPiece userId
 
@@ -62,17 +60,17 @@ authorizeRepo settings owner name (Just userId) = do
     caching = lift . withCache cacheKey
     cacheKey = CacheKey $ "auth.repo." <> T.intercalate
         "."
-        [toPathPart owner, toPathPart name, toPathPiece userId]
+        [toPathPiece owner, toPathPiece name, toPathPiece userId]
 
     -- Log this at INFO temporarily since it's important and new
     logPrivateRepoResult user canRead =
         logInfoN
             $ "GitHub user name="
-            <> maybe "<none>" toPathPart (userGithubUsername user)
+            <> maybe "<none>" toPathPiece (userGithubUsername user)
             <> " repo="
-            <> toPathPart owner
+            <> toPathPiece owner
             <> "/"
-            <> toPathPart name
+            <> toPathPiece name
             <> " can_read="
             <> tshow canRead
 

--- a/src/Backend/Application.hs
+++ b/src/Backend/Application.hs
@@ -17,7 +17,8 @@ import Control.Monad ((<=<))
 import Control.Monad.Logger (runStdoutLoggingT)
 import Database.Persist.Postgresql (createPostgresqlPool, pgConnStr, pgPoolSize)
 import Database.Redis (checkedConnect)
-import GitHub.Endpoints.Installations hiding (Repo(..))
+import GitHub.Data.AccessTokens
+import GitHub.Endpoints.Installations
 import LoadEnv (loadEnv)
 import System.Exit (ExitCode(..))
 import System.IO (BufferMode(..))
@@ -73,9 +74,9 @@ execRestyler appSettings@AppSettings {..} (Entity jobId Job {..}) = do
         let
             err = throwString $ unpack $ unlines
                 [ "No active plan for private repository: "
-                <> toPathPart (repoOwner $ entityVal repo)
+                <> toPathPiece (repoOwner $ entityVal repo)
                 <> "/"
-                <> toPathPart (repoName $ entityVal repo)
+                <> toPathPiece (repoName $ entityVal repo)
                 , ""
                 , "Contact support@restyled.io if you would like to discuss a Trial"
                 ]

--- a/src/Backend/Foundation.hs
+++ b/src/Backend/Foundation.hs
@@ -18,7 +18,7 @@ import Import
 
 import Control.Monad.Logger
 import Database.Persist.Sql (ConnectionPool)
-import Database.Redis hiding (decode, runRedis)
+import Database.Redis hiding (Desc, decode, runRedis)
 import qualified Database.Redis as Redis
 
 -- | Like @'App'@ but with no webapp-related bits
@@ -41,9 +41,10 @@ type MonadBackend m =
 -- Uses supplied settings and connections, logs to stdout
 --
 runBackend :: MonadIO m => Backend -> ReaderT Backend (LoggingT m) a -> m a
-runBackend b@Backend{..} f = runStdoutLoggingT
-    $ filterLogger (const (backendSettings `allowsLevel`))
-    $ runReaderT f b
+runBackend b@Backend {..} f =
+    runStdoutLoggingT
+        $ filterLogger (const (backendSettings `allowsLevel`))
+        $ runReaderT f b
 
 -- | Run a backend action from a Handler (e.g. enqueuing a job)
 --
@@ -56,12 +57,14 @@ runBackendHandler f = do
 
 -- | Extracted so @'runBackendTest'@ can use it in tests
 runBackendApp :: App -> ReaderT Backend (LoggingT m) a -> m a
-runBackendApp app@App{..} f = runLoggingT
-    (runReaderT f Backend
-        { backendSettings = appSettings
-        , backendConnPool = appConnPool
-        , backendRedisConn = appRedisConn
-        }
+runBackendApp app@App {..} f = runLoggingT
+    (runReaderT
+        f
+        Backend
+            { backendSettings = appSettings
+            , backendConnPool = appConnPool
+            , backendRedisConn = appRedisConn
+            }
     )
     (messageLoggerSource app appLogger)
 

--- a/src/Backend/Job.hs
+++ b/src/Backend/Job.hs
@@ -17,7 +17,7 @@ import Data.Aeson
 import Database.Persist.Sql (SqlPersistM)
 import System.Exit (ExitCode(..))
 
-insertJob :: Entity Repo -> PullRequestId -> YesodDB App (Entity Job)
+insertJob :: Entity Repo -> PullRequestNum -> YesodDB App (Entity Job)
 insertJob (Entity _ Repo {..}) pullRequestNumber = do
     now <- liftIO getCurrentTime
     insertEntity Job

--- a/src/Foundation.hs
+++ b/src/Foundation.hs
@@ -24,7 +24,6 @@ import Data.Aeson (decode, encode)
 import Database.Persist.Sql (ConnectionPool, runSqlPool)
 import Database.Redis (Connection)
 import qualified Database.Redis as Redis
-import GitHub.Instances (OwnerName, RepoName)
 import Text.Hamlet (hamletFile)
 import Text.Jasmine (minifym)
 import Yesod.Auth

--- a/src/GitHub/Endpoints/Installations.hs
+++ b/src/GitHub/Endpoints/Installations.hs
@@ -2,11 +2,7 @@
 
 module GitHub.Endpoints.Installations
     ( createAccessToken
-    , module GitHub.Data
-    , module GitHub.Data.Apps
-    , module GitHub.Data.AccessTokens
-    )
-where
+    ) where
 
 import Prelude
 
@@ -20,9 +16,9 @@ import qualified Data.Text as T
 import Data.Text.Encoding (encodeUtf8)
 import Data.Time
 import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
-import GitHub.Data
-import GitHub.Data.AccessTokens
-import GitHub.Data.Apps hiding (installationId)
+import GitHub.Data (Id, toPathPart, untagId)
+import GitHub.Data.AccessTokens (AccessToken(..))
+import GitHub.Data.Apps (App, Installation)
 import Network.HTTP.Simple
 import Network.HTTP.Types
 import qualified Web.JWT as JWT

--- a/src/Handler/Admin/Jobs.hs
+++ b/src/Handler/Admin/Jobs.hs
@@ -13,7 +13,6 @@ import Import
 
 import Backend.Foundation (runBackendHandler)
 import Backend.Job
-import GitHub.Data (toPathPart)
 import Widgets.Job
 
 getAdminJobsNewR :: Handler Html
@@ -29,7 +28,7 @@ postAdminJobsR = do
     ((result, widget), enctype) <- runFormPost createJobForm
 
     case result of
-        FormSuccess CreateJob{..} -> do
+        FormSuccess CreateJob {..} -> do
             mRepo <- runDB $ getBy $ UniqueRepo cjOwner cjRepo
 
             for_ mRepo $ \repo -> do
@@ -38,10 +37,12 @@ postAdminJobsR = do
                 setMessage "Job created"
                 redirect AdminR
 
-            setMessage $ toHtml
+            setMessage
+                $ toHtml
                 $ "Unknown Repo: "
-                <> toPathPart cjOwner <> "/"
-                <> toPathPart cjRepo
+                <> toPathPiece cjOwner
+                <> "/"
+                <> toPathPiece cjRepo
 
         _ -> setMessage "Error creating Job"
 

--- a/src/Handler/Admin/Plans.hs
+++ b/src/Handler/Admin/Plans.hs
@@ -11,15 +11,13 @@ module Handler.Admin.Plans
 
 import Import
 
-import GitHub.Data (mkName)
-
 planForm :: Form Plan
 planForm =
     renderDivs
         $ Plan
         <$> areq (selectField optionsEnum) "Type" Nothing
-        <*> (mkName Proxy <$> areq textField "Owner" Nothing)
-        <*> (mkName Proxy <$> areq textField "Repo" Nothing)
+        <*> (mkOwnerName <$> areq textField "Owner" Nothing)
+        <*> (mkRepoName <$> areq textField "Repo" Nothing)
         <*> (mkUTC <$$> aopt dayField "Active" Nothing)
         <*> (mkUTC <$$> aopt dayField "Expires" Nothing)
         <*> (unTextarea <$> areq textareaField "Message" Nothing)

--- a/src/Handler/Repos.hs
+++ b/src/Handler/Repos.hs
@@ -13,37 +13,32 @@ where
 
 import Import
 
-import GitHub.Data hiding (Repo(..))
-import qualified GitHub.Data as GH
 import Widgets.Job
 
-getRepoR :: Name Owner -> Name GH.Repo -> Handler Html
+getRepoR :: OwnerName -> RepoName -> Handler Html
 getRepoR = getRepoJobsR
 
-getRepoPullR :: Name Owner -> Name GH.Repo -> Int -> Handler Html
+getRepoPullR :: OwnerName -> RepoName -> PullRequestId -> Handler Html
 getRepoPullR = getRepoPullJobsR
 
-getRepoPullJobsR :: Name Owner -> Name GH.Repo -> Int -> Handler Html
+getRepoPullJobsR :: OwnerName -> RepoName -> PullRequestId -> Handler Html
 getRepoPullJobsR owner name num = do
     jobs <- runDB $ selectList
-        [ JobOwner ==. owner
-        , JobRepo ==. name
-        , JobPullRequest ==. mkId Proxy num
-        ]
+        [JobOwner ==. owner, JobRepo ==. name, JobPullRequest ==. num]
         [Desc JobCompletedAt, Desc JobCreatedAt]
 
     defaultLayout $ do
         setTitle
             $ toHtml
-            $ toPathPart owner
+            $ toPathPiece owner
             <> "/"
-            <> toPathPart name
+            <> toPathPiece name
             <> "#"
             <> toPathPiece num
             <> " jobs"
         $(widgetFile "jobs")
 
-getRepoJobsR :: Name Owner -> Name GH.Repo -> Handler Html
+getRepoJobsR :: OwnerName -> RepoName -> Handler Html
 getRepoJobsR owner name = do
     jobs <- runDB $ selectList
         [JobOwner ==. owner, JobRepo ==. name]
@@ -52,22 +47,22 @@ getRepoJobsR owner name = do
     defaultLayout $ do
         setTitle
             $ toHtml
-            $ toPathPart owner
+            $ toPathPiece owner
             <> "/"
-            <> toPathPart name
+            <> toPathPiece name
             <> " jobs"
         $(widgetFile "jobs")
 
-getRepoJobR :: Name Owner -> Name GH.Repo -> JobId -> Handler Html
+getRepoJobR :: OwnerName -> RepoName -> JobId -> Handler Html
 getRepoJobR owner name jobId = do
     job <- runDB $ fromMaybeM notFound =<< getEntity jobId
 
     defaultLayout $ do
         setTitle
             $ toHtml
-            $ toPathPart owner
+            $ toPathPiece owner
             <> "/"
-            <> toPathPart name
+            <> toPathPiece name
             <> " #"
             <> toPathPiece jobId
         $(widgetFile "job")

--- a/src/Handler/Repos.hs
+++ b/src/Handler/Repos.hs
@@ -18,10 +18,10 @@ import Widgets.Job
 getRepoR :: OwnerName -> RepoName -> Handler Html
 getRepoR = getRepoJobsR
 
-getRepoPullR :: OwnerName -> RepoName -> PullRequestId -> Handler Html
+getRepoPullR :: OwnerName -> RepoName -> PullRequestNum -> Handler Html
 getRepoPullR = getRepoPullJobsR
 
-getRepoPullJobsR :: OwnerName -> RepoName -> PullRequestId -> Handler Html
+getRepoPullJobsR :: OwnerName -> RepoName -> PullRequestNum -> Handler Html
 getRepoPullJobsR owner name num = do
     jobs <- runDB $ selectList
         [JobOwner ==. owner, JobRepo ==. name, JobPullRequest ==. num]

--- a/src/Handler/Webhooks.hs
+++ b/src/Handler/Webhooks.hs
@@ -35,7 +35,7 @@ handleGitHubEvent = \case
 
 handleInitialized :: Payload -> Entity Repo -> Handler a
 handleInitialized payload repo = do
-    let prNumber = mkPullRequestId $ pullRequestNumber $ pPullRequest payload
+    let prNumber = mkPullRequestNum $ pullRequestNumber $ pPullRequest payload
     job <- runDB $ insertJob repo prNumber
     runBackendHandler $ enqueueRestylerJob job
     sendResponseStatus status201 ()

--- a/src/Handler/Webhooks.hs
+++ b/src/Handler/Webhooks.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeFamilies #-}
 
 module Handler.Webhooks
     ( postWebhooksR

--- a/src/Handler/Webhooks.hs
+++ b/src/Handler/Webhooks.hs
@@ -11,7 +11,7 @@ import Import
 
 import Backend.Foundation
 import Backend.Job
-import GitHub.Data hiding (Repo(..))
+import GitHub.Data.PullRequests
 import GitHub.Data.Webhooks.PullRequest
 
 postWebhooksR :: Handler ()
@@ -35,7 +35,7 @@ handleGitHubEvent = \case
 
 handleInitialized :: Payload -> Entity Repo -> Handler a
 handleInitialized payload repo = do
-    let prNumber = mkId Proxy $ pullRequestNumber $ pPullRequest payload
+    let prNumber = mkPullRequestId $ pullRequestNumber $ pPullRequest payload
     job <- runDB $ insertJob repo prNumber
     runBackendHandler $ enqueueRestylerJob job
     sendResponseStatus status201 ()
@@ -52,9 +52,9 @@ reasonToLogMessage = \case
     OwnPullRequest branch -> "branch appears to be our own: " <> branch
     PrivateNoPlan owner repo ->
         "private repository with no plan: "
-            <> toPathPart owner
+            <> toPathPiece owner
             <> "/"
-            <> toPathPart repo
+            <> toPathPiece repo
 
 githubEventHeader :: Handler (Maybe Text)
 githubEventHeader = decodeUtf8 <$$> lookupHeader "X-GitHub-Event"

--- a/src/Model.hs
+++ b/src/Model.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -18,16 +17,12 @@ where
 
 import ClassyPrelude.Yesod
 
-import Cache
 import Database.Persist.Quasi
 import GitHub.Data (Id, Name, Owner, PullRequest)
 import qualified GitHub.Data as GH
 import GitHub.Data.Apps (Installation)
 import GitHub.Instances ()
 import Model.PlanType
-
-type DB a = forall backend m.
-    (backend ~ SqlBackend, MonadCache m, MonadHandler m) => ReaderT backend m a
 
 share [mkPersist sqlSettings, mkMigrate "migrateAll"]
     $(persistFileWith lowerCaseSettings "config/models")

--- a/src/Model.hs
+++ b/src/Model.hs
@@ -12,16 +12,14 @@
 
 module Model
     ( module Model
-    )
-where
+    , module Model.PlanType
+    , module Model.Names
+    ) where
 
 import ClassyPrelude.Yesod
 
 import Database.Persist.Quasi
-import GitHub.Data (Id, Name, Owner, PullRequest)
-import qualified GitHub.Data as GH
-import GitHub.Data.Apps (Installation)
-import GitHub.Instances ()
+import Model.Names
 import Model.PlanType
 
 share [mkPersist sqlSettings, mkMigrate "migrateAll"]

--- a/src/Model/Collaborator.hs
+++ b/src/Model/Collaborator.hs
@@ -18,8 +18,8 @@ import Control.Monad.Except
 import Data.Aeson
 import Data.Aeson.Casing
 import qualified Data.ByteString.Lazy as BL
-import GitHub.Data (toPathPart)
-import GitHub.Endpoints.Installations (AccessToken(..), createAccessToken)
+import GitHub.Data.AccessTokens
+import GitHub.Endpoints.Installations
 import Network.HTTP.Simple
 
 data RepoPermission
@@ -79,11 +79,11 @@ collaboratorCanRead settings Repo {..} User {..} = do
         request <-
             githubRequest token
             $ "/repos/"
-            <> unpack (toPathPart repoOwner)
+            <> unpack (toPathPiece repoOwner)
             <> "/"
-            <> unpack (toPathPart repoName)
+            <> unpack (toPathPiece repoName)
             <> "/collaborators/"
-            <> unpack (toPathPart username)
+            <> unpack (toPathPiece username)
             <> "/permission"
 
         response <- withExceptT show $ exceptIO $ tryIO $ httpLbs request

--- a/src/Model/Names.hs
+++ b/src/Model/Names.hs
@@ -1,26 +1,31 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module GitHub.Instances
-    (
-    -- * Route pieces
-      OwnerName
+module Model.Names
+    ( OwnerName
     , RepoName
-    )
-where
+    , InstallationId
+    , PullRequestId
+    , GitHubUserId
+    , GitHubUserName
+    ) where
 
 import Prelude
 
 import Data.Proxy
 import Data.Text (Text)
 import Database.Persist.Sql
-import GitHub.Data hiding (Repo(..))
-import qualified GitHub.Data as GH
+import GitHub.Data
+import GitHub.Data.Apps
 import Text.Blaze (ToMarkup(..))
 import Yesod.Core (PathPiece(..))
 
--- Types necessary to use Names in config/routes
 type OwnerName = Name Owner
-type RepoName = Name GH.Repo
+type RepoName = Name Repo
+type InstallationId = Id Installation
+type PullRequestId = Id PullRequest
+
+type GitHubUserId = Id User
+type GitHubUserName = Name User
 
 instance PathPiece (Id a) where
     toPathPiece = toPathPiece . untagId

--- a/src/Model/Names.hs
+++ b/src/Model/Names.hs
@@ -6,8 +6,8 @@ module Model.Names
     , RepoName
     , mkRepoName
     , InstallationId
-    , PullRequestId
-    , mkPullRequestId
+    , PullRequestNum
+    , mkPullRequestNum
     , GitHubUserId
     , GitHubUserName
     ) where
@@ -27,10 +27,10 @@ type OwnerName = Name Owner
 type RepoName = Name Repo
 type InstallationId = Id Installation
 
-type PullRequestId = Id PullRequest
+type PullRequestNum = Id PullRequest
 
-mkPullRequestId :: Int -> PullRequestId
-mkPullRequestId = mkId Proxy
+mkPullRequestNum :: Int -> PullRequestNum
+mkPullRequestNum = mkId Proxy
 
 type GitHubUserId = Id User
 type GitHubUserName = Name User

--- a/src/Model/Names.hs
+++ b/src/Model/Names.hs
@@ -2,9 +2,12 @@
 
 module Model.Names
     ( OwnerName
+    , mkOwnerName
     , RepoName
+    , mkRepoName
     , InstallationId
     , PullRequestId
+    , mkPullRequestId
     , GitHubUserId
     , GitHubUserName
     ) where
@@ -17,15 +20,23 @@ import Database.Persist.Sql
 import GitHub.Data
 import GitHub.Data.Apps
 import Text.Blaze (ToMarkup(..))
+import Text.Read
 import Yesod.Core (PathPiece(..))
 
 type OwnerName = Name Owner
 type RepoName = Name Repo
 type InstallationId = Id Installation
+
 type PullRequestId = Id PullRequest
+
+mkPullRequestId :: Int -> PullRequestId
+mkPullRequestId = mkId Proxy
 
 type GitHubUserId = Id User
 type GitHubUserName = Name User
+
+instance Read (Id a) where
+    readPrec = mkId Proxy <$> readPrec
 
 instance PathPiece (Id a) where
     toPathPiece = toPathPiece . untagId

--- a/src/Model/Repo.hs
+++ b/src/Model/Repo.hs
@@ -14,9 +14,8 @@ import ClassyPrelude
 
 import Database.Persist
 import Database.Persist.Sql (SqlPersistT)
-import GitHub.Data hiding (Repo(..), User(..))
 import qualified GitHub.Data as GH
-import GitHub.Data.Apps hiding (installationId)
+import GitHub.Data.PullRequests
 import GitHub.Data.Webhooks.PullRequest
 import Model
 
@@ -51,7 +50,7 @@ data IgnoredWebhookReason
     = IgnoredAction PullRequestEventType
     | IgnoredEventType Text
     | OwnPullRequest Text
-    | PrivateNoPlan (Name Owner) (Name GH.Repo)
+    | PrivateNoPlan OwnerName RepoName
 
 initializeFromWebhook
     :: MonadIO m
@@ -66,11 +65,11 @@ initializeFromWebhook Payload {..}
     = Right <$> findOrCreateRepo pRepository pInstallationId
 
 findOrCreateRepo
-    :: MonadIO m => GH.Repo -> Id Installation -> SqlPersistT m (Entity Repo)
+    :: MonadIO m => GH.Repo -> InstallationId -> SqlPersistT m (Entity Repo)
 findOrCreateRepo ghRepo installationId = do
     let
         repo = Repo
-            { repoOwner = simpleOwnerLogin $ GH.repoOwner ghRepo
+            { repoOwner = GH.simpleOwnerLogin $ GH.repoOwner ghRepo
             , repoName = GH.repoName ghRepo
             , repoInstallationId = installationId
             , repoIsPrivate = GH.repoPrivate ghRepo

--- a/src/Routes.hs
+++ b/src/Routes.hs
@@ -34,10 +34,10 @@ repoP = RepoP
 repoR :: OwnerName -> RepoName -> Route App
 repoR owner name = repoP owner name RepoR
 
-pullP :: PullRequestId -> RepoPullP -> RepoP
+pullP :: PullRequestNum -> RepoPullP -> RepoP
 pullP = RepoPullP
 
-pullR :: PullRequestId -> RepoP
+pullR :: PullRequestNum -> RepoP
 pullR num = pullP num RepoPullR
 
 jobsR :: RepoP
@@ -46,7 +46,7 @@ jobsR = RepoJobsP RepoJobsR
 jobR :: JobId -> RepoP
 jobR = RepoJobsP . RepoJobR
 
-pullJobsR :: PullRequestId -> RepoP
+pullJobsR :: PullRequestNum -> RepoP
 pullJobsR num = pullP num $ RepoPullJobsP RepoPullJobsR
 
 adminReposP :: AdminReposP -> Route App

--- a/src/Routes.hs
+++ b/src/Routes.hs
@@ -27,18 +27,17 @@ where
 import Import.NoFoundation
 
 import Foundation
-import qualified GitHub.Data as GH
 
-repoP :: GH.Name GH.Owner -> GH.Name GH.Repo -> RepoP -> Route App
+repoP :: OwnerName -> RepoName -> RepoP -> Route App
 repoP = RepoP
 
-repoR :: GH.Name GH.Owner -> GH.Name GH.Repo -> Route App
+repoR :: OwnerName -> RepoName -> Route App
 repoR owner name = repoP owner name RepoR
 
-pullP :: GH.Id GH.PullRequest -> RepoPullP -> RepoP
-pullP = RepoPullP . GH.untagId
+pullP :: PullRequestId -> RepoPullP -> RepoP
+pullP = RepoPullP
 
-pullR :: GH.Id GH.PullRequest -> RepoP
+pullR :: PullRequestId -> RepoP
 pullR num = pullP num RepoPullR
 
 jobsR :: RepoP
@@ -47,7 +46,7 @@ jobsR = RepoJobsP RepoJobsR
 jobR :: JobId -> RepoP
 jobR = RepoJobsP . RepoJobR
 
-pullJobsR :: GH.Id GH.PullRequest -> RepoP
+pullJobsR :: PullRequestId -> RepoP
 pullJobsR num = pullP num $ RepoPullJobsP RepoPullJobsR
 
 adminReposP :: AdminReposP -> Route App

--- a/src/Widgets/Job.hs
+++ b/src/Widgets/Job.hs
@@ -33,7 +33,7 @@ import Formatting.Time (diff)
 data CreateJob = CreateJob
     { cjOwner :: OwnerName
     , cjRepo :: RepoName
-    , cjPullRequest :: PullRequestId
+    , cjPullRequest :: PullRequestNum
     }
 
 -- | Form to use when rendering for real input, or processing
@@ -43,7 +43,7 @@ createJobForm =
         $ CreateJob
         <$> (mkOwnerName <$> areq textField "Owner" Nothing)
         <*> (mkRepoName <$> areq textField "Repo" Nothing)
-        <*> (mkPullRequestId <$> areq intField "Pull Request" Nothing)
+        <*> (mkPullRequestNum <$> areq intField "Pull Request" Nothing)
 
 --- | Form to use when re-submitting an existing @'Job'@
 createJobFormFrom :: Job -> Form CreateJob
@@ -61,7 +61,7 @@ createJobFormFromRepo Repo {..} =
         $ CreateJob
         <$> areq hiddenField "" (Just repoOwner)
         <*> areq hiddenField "" (Just repoName)
-        <*> (mkPullRequestId <$> areq intField ("" { fsAttrs = attrs }) Nothing)
+        <*> (mkPullRequestNum <$> areq intField ("" { fsAttrs = attrs }) Nothing)
     where attrs = [("placeholder", "PR Number")]
 
 -- | Internal helper for rendering completion state

--- a/templates/widgets/job-card.hamlet
+++ b/templates/widgets/job-card.hamlet
@@ -2,10 +2,10 @@ $with Entity jobId job <- job
   <div .card>
     <header>
       <a .permalink href=@{repoP (jobOwner job) (jobRepo job) $ jobR jobId}>permalink
-      #{toPathPart $ jobOwner job}
+      #{toPathPiece $ jobOwner job}
       /
       <a href=@{repoP (jobOwner job) (jobRepo job) $ jobsR}>
-        #{toPathPart $ jobRepo job}
+        #{toPathPiece $ jobRepo job}
       <a href=@{repoP (jobOwner job) (jobRepo job) $ pullJobsR $ jobPullRequest job}>
         ##{toPathPiece $ jobPullRequest job}
 

--- a/test/Handler/ReposSpec.hs
+++ b/test/Handler/ReposSpec.hs
@@ -7,9 +7,6 @@ where
 
 import TestImport
 
-import GitHub.Data hiding (Repo(..))
-import qualified GitHub.Data as GH
-
 spec :: Spec
 spec = withApp $ do
     describe "GET gh/:owner/repos/:repo" $ do
@@ -48,7 +45,7 @@ itRequiresRepositoryAccess path = do
     owner = "foo"
     name = "bar"
 
-publicRepo :: Name Owner -> Name GH.Repo -> Repo
+publicRepo :: OwnerName -> RepoName -> Repo
 publicRepo owner name = Repo
     { repoOwner = owner
     , repoName = name

--- a/test/Handler/WebhooksSpec.hs
+++ b/test/Handler/WebhooksSpec.hs
@@ -70,25 +70,30 @@ spec = withApp $ do
             statusIs 200
 
         it "ignores private repositories if no plan" $ do
+            pendingWith "Moved to Backend"
             postFixture "webhooks/github/pull-request-opened-private.json"
             statusIs 200
 
         it "ignores private repositories if inactive plan" $ do
+            pendingWith "Moved to Backend"
             setupPrivatePlan (Just 100) Nothing
             postFixture "webhooks/github/pull-request-opened-private.json"
             statusIs 200
 
         it "ignores private repositories if expired plan" $ do
+            pendingWith "Moved to Backend"
             setupPrivatePlan Nothing $ Just (-100)
             postFixture "webhooks/github/pull-request-opened-private.json"
             statusIs 200
 
         it "accepts private repositories if active plan" $ do
+            pendingWith "Moved to Backend"
             setupPrivatePlan (Just (-100)) $ Just 100
             postFixture "webhooks/github/pull-request-opened-private.json"
             statusIs 201
 
         it "accepts private repositories if forever plan" $ do
+            pendingWith "Moved to Backend"
             setupPrivatePlan Nothing Nothing
             postFixture "webhooks/github/pull-request-opened-private.json"
             statusIs 201

--- a/test/Test/Hspec/Lifted.hs
+++ b/test/Test/Hspec/Lifted.hs
@@ -1,9 +1,16 @@
 module Test.Hspec.Lifted
     ( module X
+    , module Test.Hspec.Lifted
     ) where
 
+import Prelude
+
+import Control.Monad.IO.Class
+import Test.Hspec as Hspec
 import Test.Hspec as X hiding
     ( expectationFailure
+    , pending
+    , pendingWith
     , shouldBe
     , shouldContain
     , shouldEndWith
@@ -16,7 +23,6 @@ import Test.Hspec as X hiding
     , shouldSatisfy
     , shouldStartWith
     )
-
 import Test.Hspec.Expectations.Lifted as X
     ( expectationFailure
     , shouldBe
@@ -31,3 +37,9 @@ import Test.Hspec.Expectations.Lifted as X
     , shouldSatisfy
     , shouldStartWith
     )
+
+pending :: MonadIO m => m ()
+pending = liftIO Hspec.pending
+
+pendingWith :: MonadIO m => String -> m ()
+pendingWith = liftIO . Hspec.pendingWith

--- a/test/Test/Hspec/Lifted.hs
+++ b/test/Test/Hspec/Lifted.hs
@@ -38,8 +38,5 @@ import Test.Hspec.Expectations.Lifted as X
     , shouldStartWith
     )
 
-pending :: MonadIO m => m ()
-pending = liftIO Hspec.pending
-
 pendingWith :: MonadIO m => String -> m ()
 pendingWith = liftIO . Hspec.pendingWith

--- a/test/TestImport.hs
+++ b/test/TestImport.hs
@@ -41,7 +41,6 @@ import Database.Redis (del)
 import Foundation as X
 import LoadEnv (loadEnvFrom)
 import Model as X
-import Model.PlanType as X
 import Routes as X
 import Settings (AppSettings(..), loadEnvSettings)
 import Test.Hspec.Core (SpecM)
@@ -102,12 +101,16 @@ wipeRedis :: App -> IO ()
 wipeRedis app = runBackendApp app $ runRedis $ void $ del [queueName]
 
 getTables :: MonadIO m => ReaderT SqlBackend m [Text]
-getTables = map unSingle <$> rawSql
-    [st|
-        SELECT table_name
-        FROM information_schema.tables
-        WHERE table_schema = 'public';
-    |] []
+getTables =
+    map unSingle
+        <$> rawSql
+                
+                    [st|
+                        SELECT table_name
+                        FROM information_schema.tables
+                        WHERE table_schema = 'public';
+                    |]
+                []
 
 -- | Insert and authenticate as the given user
 --

--- a/test/TestImport.hs
+++ b/test/TestImport.hs
@@ -100,17 +100,15 @@ wipeDB app = runDBWithApp app $ do
 wipeRedis :: App -> IO ()
 wipeRedis app = runBackendApp app $ runRedis $ void $ del [queueName]
 
+-- brittany-disable-next-binding
+
 getTables :: MonadIO m => ReaderT SqlBackend m [Text]
-getTables =
-    map unSingle
-        <$> rawSql
-                
-                    [st|
-                        SELECT table_name
-                        FROM information_schema.tables
-                        WHERE table_schema = 'public';
-                    |]
-                []
+getTables = map unSingle <$> rawSql
+    [st|
+        SELECT table_name
+        FROM information_schema.tables
+        WHERE table_schema = 'public';
+    |] []
 
 -- | Insert and authenticate as the given user
 --


### PR DESCRIPTION
Our response times are highly variable, and I suspect it's because the webhook
handling is doing a little too much work to check plans. We can go ahead and
insert the Job and let no-plan repositories be discarded in the Backend
instead.

This then prompted two other overdue refactors, which have been included.

We can go further in both the moving of logic to the Backend and the refactors,
but we'll stop here for now.