### PR TITLE
Avoid local EKG server if CloudWatch is disabled

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,11 +13,14 @@ jobs:
       - image: redis:4.0.2-alpine
     steps:
       - checkout
+      - run:
+          name: Digest
+          command: git ls-files | xargs md5sum > digest
       - restore_cache:
           keys:
-            - stack-{{ .Branch }}-{{ checksum "stack.yaml" }}
-            - stack-{{ .Branch }}
-            - stack-
+            - v1-{{ .Branch }}-{{ checksum "digest" }}
+            - v1-{{ .Branch }}
+            - v1-
       - run:
           name: Dependencies
           command: |
@@ -33,7 +36,7 @@ jobs:
           name: Lint
           command: make lint
       - save_cache:
-          key: stack-{{ .Branch }}-{{ checksum "stack.yaml" }}
+          key: v1-{{ .Branch }}-{{ checksum "digest" }}
           paths:
             - ~/.stack
             - ./.stack-work

--- a/src/Application.hs
+++ b/src/Application.hs
@@ -135,8 +135,7 @@ appMain = do
 
     let store = amStore $ appMetrics foundation
 
-    if appCloudWatchEKG settings
-        then forkCloudWatchServer store
-        else forkLocalhostServer store 8000
+    when (appCloudWatchEKG settings) $ forkCloudWatchServer store
+    when (appLocalEKG settings) $ forkLocalhostServer store 8000
 
     runSettings (warpSettings foundation) app

--- a/src/Backend/Application.hs
+++ b/src/Backend/Application.hs
@@ -46,9 +46,8 @@ backendMain = do
     backendMetrics <- buildAppMetrics
 
     let store = amStore backendMetrics
-    if appCloudWatchEKG backendSettings
-        then forkCloudWatchServer store
-        else forkLocalhostServer store 8001
+    when (appCloudWatchEKG backendSettings) $ forkCloudWatchServer store
+    when (appLocalEKG backendSettings) $ forkLocalhostServer store 8001
 
     runBackend Backend {..} $ forever $ awaitAndProcessJob 120
 

--- a/src/Settings.hs
+++ b/src/Settings.hs
@@ -66,6 +66,7 @@ data AppSettings = AppSettings
     -- verified with GitHub.
     , appAllowDummyAuth :: Bool
     , appCloudWatchEKG :: Bool
+    , appLocalEKG :: Bool
     }
 
 instance Show AppSettings where
@@ -133,6 +134,7 @@ envSettings = AppSettings
     <*> Env.switch "AUTH_DUMMY_LOGIN" mempty
 #endif
     <*> Env.switch "CLOUDWATCH_EKG" mempty
+    <*> Env.switch "LOCAL_EKG" mempty
 
 envDatabaseConfig :: EnvParser PostgresConf
 envDatabaseConfig = PostgresConf


### PR DESCRIPTION
The CloudWatch EKG server seems to be pretty CPU/Memory hungry, so we're going
to shut it off for now. We don't want that to implicitly flip over to running a
useless local EKG server. To avoid that, we split the setting.

Also change CI caching strategy to try and speed the Load/Save up (after this
first cold-cache run, of course).