### PR TITLE
Accept Webhooks immediately

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -19,10 +19,10 @@ library:
     - aeson-casing
     - blaze-markup
     - bytestring
-    - case-insensitive
     - classy-prelude
     - classy-prelude-yesod
     - conduit
+    - conduit-extra
     - containers
     - directory
     - envparse

--- a/src/Backend/AcceptedJob.hs
+++ b/src/Backend/AcceptedJob.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+
+-- | Type and handler for Jobs that we accept or ignored
+module Backend.AcceptedJob
+    ( AcceptedJob(..)
+    , acceptJob
+    , IgnoredJob(..)
+    )
+where
+
+import Import.NoFoundation
+
+import Backend.AcceptedWebhook
+import Backend.Marketplace
+import Control.Monad.Except
+import qualified Data.Text as T
+
+data AcceptedJob = AcceptedJob
+    { ajRepo :: Entity Repo
+    , ajJob :: Entity Job
+    }
+
+newtype IgnoredJob = IgnoredJob
+    { unIgnoredJob :: Entity Job
+    }
+
+-- | Given an Accepted webhook, accept or ignore that Job
+acceptJob :: MonadIO m => AcceptedWebhook -> ExceptT IgnoredJob m AcceptedJob
+acceptJob AcceptedWebhook {..} = do
+    when (repoSvcs repo /= GitHubSVCS) $ ignoreJob $ NonGitHubRepo repo
+    whenMarketplacePlanForbids allows $ ignoreJob . PlanLimitation repo
+    pure $ AcceptedJob awRepo awJob
+  where
+    repo = entityVal awRepo
+    allows = awMarketplaceAllows
+    ignoreJob = throwError <=< toIgnoredJob awJob
+
+data IgnoredJobReason
+    = NonGitHubRepo Repo
+    | PlanLimitation Repo MarketplacePlanLimitation
+
+toIgnoredJob :: MonadIO m => Entity Job -> IgnoredJobReason -> m IgnoredJob
+toIgnoredJob (Entity jobId job) reason = do
+    now <- liftIO getCurrentTime
+
+    pure $ IgnoredJob $ Entity
+        jobId
+        job
+            { jobUpdatedAt = now
+            , jobCompletedAt = Just now
+            , jobExitCode = Just 0
+            , jobStdout = Just $ toIgnoredJobStdout reason
+            , jobStderr = Just ""
+            }
+
+toIgnoredJobStdout :: IgnoredJobReason -> Text
+toIgnoredJobStdout = T.unlines . \case
+    NonGitHubRepo repo ->
+        [ "Non-GitHub (" <> tshow (repoSvcs repo) <> "): " <> path repo <> "."
+        , "See https://github.com/restyled-io/restyled.io/issues/76"
+        ]
+    PlanLimitation repo MarketplacePlanNotFound ->
+        [ "No active plan for private repository: " <> path repo <> "."
+        , "Contact support@restyled.io if you would like to discuss a Trial"
+        ]
+    PlanLimitation _ MarketplacePlanPublicOnly ->
+        [ "Your plan does not allow private repositories."
+        , "Contact support@restyled.io if you would like to discuss a Trial"
+        ]
+  where
+    path :: Repo -> Text
+    path Repo {..} = repoPath repoOwner repoName

--- a/src/Backend/AcceptedWebhook.hs
+++ b/src/Backend/AcceptedWebhook.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+-- | Type and handler for a Webhook we've decided to accept
+module Backend.AcceptedWebhook
+    ( AcceptedWebhook(..)
+    , acceptWebhook
+    )
+where
+
+import Import hiding (runDB)
+
+import Backend.DB
+import Backend.Foundation
+import Backend.Job
+import Backend.Marketplace
+import Control.Monad.Except
+import Data.Aeson
+import SVCS.GitHub.Webhook (GitHubPayload(..))
+
+data AcceptedWebhook = AcceptedWebhook
+    { awRepo :: Entity Repo
+    , awJob :: Entity Job
+    , awMarketplaceAllows :: MarketplacePlanAllows
+    }
+
+acceptWebhook
+    :: MonadBackend m
+    => ByteString
+    -> ExceptT IgnoredWebhookReason m AcceptedWebhook
+acceptWebhook body = do
+    payload <-
+        fmap unGitHubPayload
+        $ withExceptT InvalidJSON
+        $ ExceptT
+        $ pure
+        $ eitherDecodeStrict body
+
+    repo <- ExceptT $ runDB $ initializeFromWebhook payload
+
+    lift
+        $ runDB
+        $ AcceptedWebhook repo
+        <$> insertJob repo (pPullRequest payload)
+        <*> marketplacePlanAllows repo

--- a/src/Backend/ExecRestyler.hs
+++ b/src/Backend/ExecRestyler.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+
+-- | Execution of the Restyler process
+module Backend.ExecRestyler
+    ( ExecRestyler(..)
+    , FailedExecRestyler(..)
+    , SucceededExecRestyler(..)
+    , runExecRestyler
+    )
+where
+
+import Import
+
+import Backend.AcceptedJob
+import Control.Monad.Except
+import System.Exit (ExitCode(..))
+
+-- | TODO: try not to need @'Entity'@s
+newtype ExecRestyler m = ExecRestyler
+    { unExecRestyler :: Entity Repo -> Entity Job -> m (ExitCode, String, String)
+    }
+
+newtype FailedExecRestyler = FailedExecRestyler
+    { unFailedExecRestyler :: Entity Job
+    }
+
+newtype SucceededExecRestyler = SucceededExecRestyler
+    { unSucceededExecRestyler :: Entity Job
+    }
+
+runExecRestyler
+    :: MonadUnliftIO m
+    => ExecRestyler m
+    -> AcceptedJob
+    -> ExceptT FailedExecRestyler m SucceededExecRestyler
+runExecRestyler (ExecRestyler execRestyler) AcceptedJob {..} = do
+    now <- liftIO getCurrentTime
+    fmap (success now)
+        $ withExceptT (failure now)
+        $ ExceptT
+        $ tryAny
+        $ execRestyler ajRepo ajJob
+  where
+    Entity jobId job = ajJob
+
+    success now (ec', out, err) =
+        let
+            ec = case ec' of
+                ExitSuccess -> 0
+                ExitFailure c -> c
+        in
+            SucceededExecRestyler $ Entity
+                jobId
+                job
+                    { jobUpdatedAt = now
+                    , jobCompletedAt = Just now
+                    , jobExitCode = Just ec
+                    , jobStdout = Just $ pack out
+                    , jobStderr = Just $ pack err
+                    }
+
+    failure now ex = FailedExecRestyler $ Entity
+        jobId
+        job
+            { jobUpdatedAt = now
+            , jobCompletedAt = Just now
+            , jobExitCode = Just 99
+            , jobStdout = Just ""
+            , jobStderr = Just $ tshow ex
+            }

--- a/src/Backend/Job.hs
+++ b/src/Backend/Job.hs
@@ -17,7 +17,8 @@ import Backend.Foundation
 import Data.Aeson
 import System.Exit (ExitCode(..))
 
-insertJob :: Entity Repo -> PullRequestNum -> YesodDB App (Entity Job)
+insertJob
+    :: MonadIO m => Entity Repo -> PullRequestNum -> SqlPersistT m (Entity Job)
 insertJob (Entity _ Repo {..}) pullRequestNumber = do
     now <- liftIO getCurrentTime
     insertEntity Job
@@ -33,7 +34,7 @@ insertJob (Entity _ Repo {..}) pullRequestNumber = do
         , jobStderr = Nothing
         }
 
-insertJobRetry :: Job -> YesodDB App (Entity Job)
+insertJobRetry :: MonadIO m => Job -> SqlPersistT m (Entity Job)
 insertJobRetry job = do
     now <- liftIO getCurrentTime
     insertEntity Job

--- a/src/Backend/Marketplace.hs
+++ b/src/Backend/Marketplace.hs
@@ -8,6 +8,7 @@ module Backend.Marketplace
     , MarketplacePlanAllows(..)
     , MarketplacePlanLimitation(..)
     , marketplacePlanAllows
+    , whenMarketplacePlanForbids
     , isPrivateRepoPlan
     )
 where
@@ -125,6 +126,14 @@ marketplacePlanAllows (Entity _ Repo {..}) = do
         (True, Just plan)
             | isPrivateRepoPlan plan -> MarketplacePlanAllows
             | otherwise -> MarketplacePlanForbids MarketplacePlanPublicOnly
+
+whenMarketplacePlanForbids
+    :: Applicative f
+    => MarketplacePlanAllows
+    -> (MarketplacePlanLimitation -> f ())
+    -> f ()
+whenMarketplacePlanForbids MarketplacePlanAllows _ = pure ()
+whenMarketplacePlanForbids (MarketplacePlanForbids limitation) f = f limitation
 
 isPrivateRepoPlan :: MarketplacePlan -> Bool
 isPrivateRepoPlan MarketplacePlan {..} =

--- a/src/Backend/Webhook.hs
+++ b/src/Backend/Webhook.hs
@@ -1,0 +1,80 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Backend.Webhook
+    ( enqueueWebhook
+    , awaitWebhook
+    , webhookQueueName
+
+    -- * Processing
+    , processWebhook
+    , processWebhookExceptT
+    )
+where
+
+import Import hiding (runDB, timeout)
+
+import Backend.AcceptedJob
+import Backend.AcceptedWebhook
+import Backend.DB
+import Backend.ExecRestyler
+import Backend.Foundation
+import Control.Monad.Except
+
+enqueueWebhook :: MonadBackend m => ByteString -> m ()
+enqueueWebhook body = do
+    logDebugN "Enqueuing Webhook..."
+    void $ runRedis $ lpush webhookQueueName [body]
+
+awaitWebhook :: MonadBackend m => Integer -> m (Maybe ByteString)
+awaitWebhook timeout = do
+    logDebugN "Awaiting Webhook..."
+    eresult <- runRedis $ brpop [webhookQueueName] timeout
+    logDebugN $ "Popped value: " <> tshow eresult
+    pure $ either (const Nothing) (snd <$>) eresult
+
+webhookQueueName :: ByteString
+webhookQueueName = "restyled:hooks:webhooks"
+
+data JobNotProcessed
+    = WebhookIgnored IgnoredWebhookReason
+    | JobIgnored IgnoredJob
+    | ExecRestylerFailure FailedExecRestyler
+
+processWebhook :: MonadBackend m => ExecRestyler m -> ByteString -> m ()
+processWebhook execRestyler body = do
+    result <- runExceptT $ processWebhookExceptT execRestyler body
+
+    mUpdatedJob <- case result of
+        Left (WebhookIgnored reason) -> do
+            logDebugN $ "Webhook ignored: " <> reasonToLogMessage reason
+            pure Nothing
+        Left (JobIgnored (IgnoredJob job)) -> do
+            logWarnN "Job ignored"
+            logDebugN $ jOut job
+            pure $ Just job
+        Left (ExecRestylerFailure (FailedExecRestyler job)) -> do
+            logErrorN $ "ExecRestyler failure: " <> jErr job
+            pure $ Just job
+        Right (SucceededExecRestyler job) -> do
+            logInfoN "ExecRestyler succeed"
+            pure $ Just job
+
+    for_ mUpdatedJob $ runDB . replaceEntity
+  where
+    jOut = fromMaybe "" . jobStdout . entityVal
+    jErr = fromMaybe "" . jobStderr . entityVal
+    replaceEntity (Entity k v) = replace k v
+
+-- brittany-disable-next-binding
+
+processWebhookExceptT
+    :: MonadBackend m
+    => ExecRestyler m
+    -> ByteString
+    -> ExceptT JobNotProcessed m SucceededExecRestyler
+processWebhookExceptT execRestyler =
+    withExceptT WebhookIgnored . acceptWebhook
+        >=> withExceptT JobIgnored . acceptJob
+        >=> withExceptT ExecRestylerFailure . runExecRestyler execRestyler

--- a/src/Handler/Webhooks.hs
+++ b/src/Handler/Webhooks.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -53,12 +52,6 @@ handleDiscarded :: MonadHandler m => IgnoredWebhookReason -> m a
 handleDiscarded reason = do
     logWarnN $ "Webhook discarded: " <> reasonToLogMessage reason
     sendResponseStatus status200 ()
-
-reasonToLogMessage :: IgnoredWebhookReason -> Text
-reasonToLogMessage = \case
-    IgnoredAction action -> "ignored action: " <> tshow action
-    IgnoredEventType event -> "ignored event: " <> tshow event
-    OwnPullRequest author -> "PR appears to be our own, author=" <> author
 
 rejectRequest :: MonadHandler m => m a
 rejectRequest = do

--- a/src/Handler/Webhooks.hs
+++ b/src/Handler/Webhooks.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeApplications #-}
-
 module Handler.Webhooks
     ( postWebhooksR
     )
@@ -9,51 +6,11 @@ where
 import Import
 
 import Backend.Foundation
-import Backend.Job
-import Data.CaseInsensitive (CI)
-import SVCS.GitHub.Webhook
-import SVCS.GitLab.Webhook
+import Backend.Webhook
+import Data.Conduit.Binary
 
 postWebhooksR :: Handler ()
-postWebhooksR = void $ runMaybeT $ asum
-    [ handleWebhook "X-GitHub-Event" "pull_request" unGitHubPayload
-    , handleWebhook "X-GitLab-Event" "Merge Request Hook" unGitLabPayload
-    , rejectRequest
-    ]
-
-handleWebhook
-    :: FromJSON a
-    => CI ByteString -- ^ Header name for event type
-    -> Text -- ^ Header value for PR event(s)
-    -> (a -> Payload) -- ^ How to unwrap this SVCS' payload to @'Payload'@
-    -> MaybeT Handler ()
-handleWebhook header event unwrap = do
-    value <- decodeUtf8 <$> MaybeT (lookupHeader header)
-
-    if value == event
-        then lift $ do
-            payload <- unwrap <$> requireCheckJsonBody
-            logDebugN $ "Webhook received: " <> tshow payload
-
-            result <- runDB $ initializeFromWebhook payload
-            either handleDiscarded (handleInitialized payload) result
-        else do
-            payload <- requireCheckJsonBody
-            logDebugN $ "Webhook received: " <> tshow @Value payload
-            handleDiscarded $ IgnoredEventType value
-
-handleInitialized :: Payload -> Entity Repo -> Handler a
-handleInitialized payload repo = do
-    job <- runDB $ insertJob repo $ pPullRequest payload
-    runBackendHandler $ enqueueRestylerJob job
-    sendResponseStatus status201 ()
-
-handleDiscarded :: MonadHandler m => IgnoredWebhookReason -> m a
-handleDiscarded reason = do
-    logWarnN $ "Webhook discarded: " <> reasonToLogMessage reason
-    sendResponseStatus status200 ()
-
-rejectRequest :: MonadHandler m => m a
-rejectRequest = do
-    logDebugN "Rejecting webhook request"
-    sendResponseStatus status400 ()
+postWebhooksR = do
+    body <- runConduit $ rawRequestBody .| sinkLbs
+    runBackendHandler $ enqueueWebhook $ toStrict body
+    sendResponseStatus status201 ""

--- a/src/Model/Repo.hs
+++ b/src/Model/Repo.hs
@@ -77,7 +77,6 @@ data IgnoredWebhookReason
     | IgnoredAction PullRequestEventType
     | IgnoredEventType Text
     | OwnPullRequest Text
-    deriving Show
 
 reasonToLogMessage :: IgnoredWebhookReason -> Text
 reasonToLogMessage = \case

--- a/src/Model/Repo.hs
+++ b/src/Model/Repo.hs
@@ -77,6 +77,7 @@ data IgnoredWebhookReason
     | IgnoredAction PullRequestEventType
     | IgnoredEventType Text
     | OwnPullRequest Text
+    deriving Show
 
 reasonToLogMessage :: IgnoredWebhookReason -> Text
 reasonToLogMessage = \case

--- a/src/Model/Repo.hs
+++ b/src/Model/Repo.hs
@@ -4,8 +4,15 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Model.Repo
-    ( repoPath
+    (
+    -- * Virtual attributes
+      repoPath
     , repoPullPath
+
+    -- * Queries
+    , fetchReposByOwnerName
+
+    -- * Decorated
     , RepoWithStats(..)
     , repoWithStats
 
@@ -13,7 +20,6 @@ module Model.Repo
     , IgnoredWebhookReason(..)
     , reasonToLogMessage
     , initializeFromWebhook
-    , fetchReposByOwnerName
     )
 where
 

--- a/test/Handler/WebhooksSpec.hs
+++ b/test/Handler/WebhooksSpec.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
 
 module Handler.WebhooksSpec
     ( spec
@@ -8,71 +7,31 @@ where
 
 import TestImport
 
-import Backend.Job
+import Backend.Webhook
 import qualified Data.ByteString.Lazy as LB
 import qualified Data.ByteString.Lazy.Char8 as L8
-import qualified Prelude as Unsafe
 
 spec :: Spec
 spec = withApp $ do
     describe "POST /webhooks" $ do
-        it "responds 201 for opened PRs" $ do
-            postFixture "webhooks/github/pull-request-opened.json"
+        it "stores the body and responds 201" $ do
+            body <- readFixture "webhooks/github/pull-request-opened.json"
+
+            request $ do
+                setUrl WebhooksR
+                setMethod "POST"
+                setRequestBody body
+
             statusIs 201
+            runBackendTest (awaitWebhook 5)
+                `shouldReturn` Just (LB.toStrict body)
 
-        it "creates and enqueues a job record" $ do
-            postFixture "webhooks/github/pull-request-opened.json"
-            statusIs 201
-
-            Just jobD <- runDB $ selectFirst [] []
-            Just jobQ <- runBackendTest $ awaitRestylerJob 5
-
-            entityKey jobD `shouldBe` entityKey jobQ
-            jobOwner (entityVal jobD) `shouldBe` "restyled-io"
-            jobRepo (entityVal jobD) `shouldBe` "demo"
-            jobPullRequest (entityVal jobD) `shouldBe` 1
-
-        it "finds or creates the repository" $ do
-            replicateM_ 3 $ do
-                postFixture "webhooks/github/pull-request-opened.json"
-                statusIs 201
-
-            repos <- runDB $ selectList [] []
-            length repos `shouldBe` 1
-            let Repo {..} = entityVal $ Unsafe.head repos
-            repoOwner `shouldBe` "restyled-io"
-            repoName `shouldBe` "demo"
-            repoIsPrivate `shouldBe` False
-            jobs <- runDB $ selectList [] []
-            map (jobOwner . entityVal) jobs `shouldBe` replicate 3 repoOwner
-            map (jobRepo . entityVal) jobs `shouldBe` replicate 3 repoName
-
-        it "responds 200 for valid but ignored payloads" $ do
-            postFixtureAs "ping" "webhooks/ping.json"
-            statusIs 200
-
-            -- Unknown event type
-            postGitHubEvent "push" "{}"
-            statusIs 200
-
-        it "responds 4XX for invalid payloads" $ do
-            -- Invalid body
-            postGitHubEvent "pull_request" "{}"
-            statusIs 400
-
-            -- No X-GitHub-Event header
-            postBody WebhooksR "{}"
-            statusIs 400
-
-        it "ignores its own PRs" $ do
-            postFixture "webhooks/github/pull-request-opened-restyled.json"
-            statusIs 200
-
-postFixture :: FilePath -> YesodExample App ()
-postFixture = postFixtureAs "pull_request"
-
-postFixtureAs :: ByteString -> FilePath -> YesodExample App ()
-postFixtureAs event = postGitHubEvent event <=< readFixture
+        -- TODO: We need to add tests on processWebhook to cover these and more:
+        -- it "creates and enqueues a job record" $ do
+        -- it "finds or creates the repository" $ do
+        -- it "responds 200 for valid but ignored payloads" $ do
+        -- it "responds 4XX for invalid payloads" $ do
+        -- it "ignores its own PRs" $ do
 
 readFixture :: MonadIO m => FilePath -> m LB.ByteString
 readFixture = liftIO . L8.readFile . ("fixtures" </>)


### PR DESCRIPTION
Move all processing logic to the Backend, and leave the /webhooks handler to do
almost nothing.

This makes it less likely we ever drop a webhook, since the Backend queue is
persisted storage. It also means that, if we ever want, we can move webhooks
handling to a separate service (e.g. Lambda) that just pushes the Request body
to the Webhooks Queue in the naive way.