### PR TITLE
Remove guards in simple Job queue

### DIFF
--- a/src/Backend/Application.hs
+++ b/src/Backend/Application.hs
@@ -25,16 +25,16 @@ backendMain = do
     backend <- loadBackend
 
     runRIO backend $ do
-        -- LEGACY: flush old pre-processed Jobs queue
-        void $ async $ forever $ awaitAndProcessJob 120
         void $ async synchronizeMarketplacePlans
+        void $ async $ forever $ awaitAndProcessJob 120
         forever $ awaitAndProcessWebhook 120
 
 awaitAndProcessJob
     :: (HasLogFunc env, HasSettings env, HasDB env, HasRedis env)
     => Integer
     -> RIO env ()
-awaitAndProcessJob = traverse_ processJob <=< awaitRestylerJob
+awaitAndProcessJob = traverse_ processJob' <=< awaitRestylerJob
+    where processJob' = processJob $ ExecRestyler execRestyler
 
 awaitAndProcessWebhook
     :: (HasLogFunc env, HasSettings env, HasDB env, HasRedis env)
@@ -42,58 +42,6 @@ awaitAndProcessWebhook
     -> RIO env ()
 awaitAndProcessWebhook = traverse_ processWebhook' <=< awaitWebhook
     where processWebhook' = processWebhook $ ExecRestyler execRestyler
-
--- brittany-next-binding --columns=85
-
-processJob
-    :: (HasLogFunc env, HasSettings env, HasDB env) => Entity Job -> RIO env ()
-processJob job@(Entity jobId Job {..}) = do
-    logInfo
-        $ fromString
-        $ unpack
-        $ "Processing Restyler Job Id "
-        <> toPathPiece jobId
-        <> ": "
-        <> repoPullPath jobOwner jobRepo jobPullRequest
-
-    result <- runDB $ guardRepositoryJob job
-    processResult <- case result of
-        RepoNotFound -> jobSkipped "Repo not found"
-        NonGitHub repo -> jobSkipped $ nonGitHubMsg repo
-        PlanChecked (MarketplacePlanForbids limitation) repo ->
-            jobSkipped $ planLimitation limitation repo
-        PlanChecked MarketplacePlanAllows repo ->
-            handleAny (jobFailed . show) $ execRestyler repo job
-
-    now <- liftIO getCurrentTime
-    runDB $ replace jobId $ completeJob now processResult $ entityVal job
-
-jobSkipped :: Applicative f => String -> f (ExitCode, String, String)
-jobSkipped msg = pure (ExitSuccess, "", "Job skipped: " <> msg)
-
-jobFailed :: HasLogFunc env => String -> RIO env (ExitCode, String, String)
-jobFailed msg = do
-    logError $ fromString msg
-    pure (ExitFailure 1, "", msg)
-
-data JobGuardResult
-    = RepoNotFound
-    | NonGitHub (Entity Repo)
-    | PlanChecked MarketplacePlanAllows (Entity Repo)
-
-guardRepositoryJob :: MonadIO m => Entity Job -> SqlPersistT m JobGuardResult
-guardRepositoryJob (Entity _ Job {..}) = do
-    mRepo <- getBy $ UniqueRepo jobSvcs jobOwner jobRepo
-    maybe (pure RepoNotFound) checkRepo mRepo
-  where
-    checkRepo repo
-        | isNonGitHub repo = pure $ NonGitHub repo
-        | otherwise = checkPlan repo
-
-    checkPlan repo = PlanChecked <$> marketplacePlanAllows repo <*> pure repo
-
-isNonGitHub :: Entity Repo -> Bool
-isNonGitHub = (/= GitHubSVCS) . repoSvcs . entityVal
 
 -- brittany-disable-next-binding
 
@@ -137,22 +85,3 @@ execRestyler (Entity _ Repo {..}) (Entity jobId Job {..}) = do
             ]
         )
         eAccessToken
-
-nonGitHubMsg :: Entity Repo -> String
-nonGitHubMsg (Entity _ Repo {..}) = unlines
-    [ "Non-GitHub (" <> show repoSvcs <> "): " <> path <> "."
-    , "See https://github.com/restyled-io/restyled.io/issues/76"
-    ]
-    where path = unpack $ repoPath repoOwner repoName
-
-planLimitation :: MarketplacePlanLimitation -> Entity Repo -> String
-planLimitation MarketplacePlanNotFound (Entity _ Repo {..}) = unlines
-    [ "No active plan for private repository: " <> path <> "."
-    , "Contact support@restyled.io if you would like to discuss a Trial"
-    ]
-    where path = unpack $ repoPath repoOwner repoName
-
-planLimitation MarketplacePlanPublicOnly _ = unlines
-    [ "Your plan does not allow private repositories."
-    , "Contact support@restyled.io if you would like to discuss a Trial"
-    ]

--- a/src/Backend/Import.hs
+++ b/src/Backend/Import.hs
@@ -6,7 +6,7 @@ where
 
 import RIO as X hiding (timeout)
 
-import Control.Error.Util as X (hush, hushT, note, noteT, (??))
+import Control.Error.Util as X (bimapExceptT, hush, hushT, note, noteT, (??))
 import Control.Monad.Except as X
     (ExceptT(..), liftEither, runExceptT, throwError, withExceptT)
 import Control.Monad.Extra as X (fromMaybeM)

--- a/src/Model/Job.hs
+++ b/src/Model/Job.hs
@@ -3,6 +3,7 @@ module Model.Job
     , insertJobRetry
     , completeJob
     , completeJobErrored
+    , completeJobErroredS
     , completeJobSkipped
     )
 where
@@ -59,8 +60,11 @@ completeJob now (ec, out, err) job = job
     toInt ExitSuccess = 0
     toInt (ExitFailure i) = i
 
-completeJobErrored :: UTCTime -> SomeException -> Job -> Job
-completeJobErrored now ex = completeJob now (ExitFailure 99, "", show ex)
+completeJobErrored :: UTCTime -> String -> Job -> Job
+completeJobErrored now reason = completeJob now (ExitFailure 99, "", reason)
+
+completeJobErroredS :: Show a => UTCTime -> a -> Job -> Job
+completeJobErroredS now = completeJobErrored now . show
 
 completeJobSkipped :: UTCTime -> String -> Job -> Job
 completeJobSkipped now reason = completeJob now (ExitSuccess, reason, "")

--- a/src/Model/Repo.hs
+++ b/src/Model/Repo.hs
@@ -8,6 +8,7 @@ module Model.Repo
 
     -- * Queries
     , fetchReposByOwnerName
+    , fetchRepoForJob
 
     -- * Decorated
     , RepoWithStats(..)
@@ -68,6 +69,11 @@ repoWithStats repo =
 fetchReposByOwnerName :: MonadIO m => OwnerName -> SqlPersistT m [Entity Repo]
 fetchReposByOwnerName owner =
     selectList [RepoOwner ==. owner] [Asc RepoName, LimitTo 10]
+
+fetchRepoForJob :: MonadIO m => Job -> SqlPersistT m (Maybe (Entity Repo))
+fetchRepoForJob Job {..} = selectFirst
+    [RepoSvcs ==. jobSvcs, RepoOwner ==. jobOwner, RepoName ==. jobRepo]
+    []
 
 data IgnoredWebhookReason
     = InvalidJSON String


### PR DESCRIPTION
This queue only handles retries and we only allow retries on
pre-accepted Jobs (as indicate by the types in the new processJob
function), so we don't need these same guards again.