### PR TITLE
Implement seam for tracking processes live

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -98,7 +98,6 @@ library:
     - persistent
     - persistent-postgresql
     - persistent-template
-    - process
     - rio
     - rio-orphans
     - safe-exceptions

--- a/src/Application.hs
+++ b/src/Application.hs
@@ -37,6 +37,7 @@ import RIO (logFuncUseColorL, runRIO, view)
 import RIO.DB (createConnectionPool)
 import RIO.Logger
 import RIO.Orphans ()
+import RIO.Process
 import System.Log.FastLogger (defaultBufSize, newStdoutLoggerSet, toLogStr)
 import Yesod.Auth
 
@@ -60,6 +61,7 @@ makeFoundation :: AppSettings -> IO App
 makeFoundation appSettings = do
     appHttpManager <- getGlobalManager
     appLogFunc <- terminalLogFunc $ loggerLogLevel $ appLogLevel appSettings
+    appProcessContext <- mkDefaultProcessContext
     appStatic <- (if appMutableStatic appSettings then staticDevel else static)
         appStaticDir
     appRedisConn <- checkedConnect $ appRedisConf appSettings

--- a/src/Backend/Application.hs
+++ b/src/Backend/Application.hs
@@ -9,9 +9,9 @@ import Backend.ExecRestyler
 import Backend.Foundation
 import Backend.Job
 import Backend.Marketplace
+import Backend.RestyleMachine
 import Backend.Webhook
 import Control.Monad ((<=<))
-import Model.RestyleMachine (runRestyleMachine)
 import RIO.Process
 import RIO.Process.Follow
 import SVCS.GitHub.AccessToken (githubInstallationToken)

--- a/src/Backend/Import.hs
+++ b/src/Backend/Import.hs
@@ -23,7 +23,6 @@ import Database.Persist.Sql as X (SqlPersistT)
 import Model as X
 import Model.Job as X
 import Model.Repo as X
-import Model.RestyleMachine as X
 import Model.User as X
 import RIO.DB as X
 import RIO.Redis as X

--- a/src/Backend/Import.hs
+++ b/src/Backend/Import.hs
@@ -34,5 +34,8 @@ import Web.PathPieces as X
 fromJustNoteM :: MonadIO m => String -> Maybe a -> m a
 fromJustNoteM msg = fromMaybeM (throwString msg) . pure
 
+fromLeftM :: Monad m => (a -> m b) -> m (Either a b) -> m b
+fromLeftM f me = either f pure =<< me
+
 overEntity :: Entity a -> (a -> a) -> Entity a
 overEntity e f = e { entityVal = f $ entityVal e }

--- a/src/Backend/RestyleMachine.hs
+++ b/src/Backend/RestyleMachine.hs
@@ -1,5 +1,4 @@
--- | FIXME: this should be in Backend, not Model
-module Model.RestyleMachine
+module Backend.RestyleMachine
     ( runRestyleMachine
     )
 where

--- a/src/Foundation.hs
+++ b/src/Foundation.hs
@@ -15,6 +15,7 @@ import Database.Persist.Sql (ConnectionPool, runSqlPool)
 import Database.Redis (Connection)
 import RIO (HasLogFunc(..), LogFunc, lens)
 import RIO.DB hiding (runDB)
+import RIO.Process
 import RIO.Redis
 import Text.Hamlet (hamletFile)
 import Text.Jasmine (minifym)
@@ -32,11 +33,16 @@ data App = App
     , appRedisConn :: Connection
     , appHttpManager :: Manager
     , appLogFunc :: LogFunc
+    , appProcessContext :: ProcessContext
     }
 
 instance HasLogFunc App where
     logFuncL = lens appLogFunc $ \x y -> x
         { appLogFunc = y }
+
+instance HasProcessContext App where
+    processContextL = lens appProcessContext $ \x y -> x
+        { appProcessContext = y }
 
 instance HasSettings App where
     settingsL = lens appSettings $ \x y -> x

--- a/src/Handler/Admin/Machines.hs
+++ b/src/Handler/Admin/Machines.hs
@@ -11,7 +11,7 @@ module Handler.Admin.Machines
 
 import Import
 
-import Model.RestyleMachine (runRestyleMachine)
+import Backend.RestyleMachine
 import RIO.Process.Follow
 import System.Exit (ExitCode(..))
 

--- a/src/RIO/Process/Follow.hs
+++ b/src/RIO/Process/Follow.hs
@@ -1,0 +1,87 @@
+module RIO.Process.Follow
+    ( followProcess
+    , captureFollowedProcess
+    , captureFollowedProcessWith
+    )
+where
+
+import RIO
+
+import RIO.Process
+import System.IO (hGetLine)
+import System.IO.Error (isEOFError)
+
+-- | Run a process and execute an action on each line of output
+followProcess
+    :: (HasLogFunc env, HasProcessContext env)
+    => FilePath
+    -- ^ Command
+    -> [String]
+    -- ^ Arguments
+    -> (String -> RIO env ())
+    -- ^ Called with each line of @stdout@
+    -> (String -> RIO env ())
+    -- ^ Called with each line of @stderr@
+    -> RIO env ExitCode
+followProcess cmd args fOut fErr =
+    proc cmd args $ \pc -> withProcess (setPipes pc) $ \p -> do
+        aOut <- async $ followPipe (getStdout p) fOut
+        aErr <- async $ followPipe (getStderr p) fErr
+        ec <- waitExitCode p
+        ec <$ traverse_ wait [aOut, aErr]
+
+setPipes :: ProcessConfig stdin stdout stderr -> ProcessConfig () Handle Handle
+setPipes = setStdin closed . setStdout createPipe . setStderr createPipe
+
+followPipe :: MonadUnliftIO m => Handle -> (String -> m ()) -> m ()
+followPipe hdl act = loop `catch` handleEOF
+  where
+    loop = do
+        ln <- liftIO $ hGetLine hdl
+        act ln
+        followPipe hdl act
+
+    handleEOF ex
+        | isEOFError ex = pure ()
+        | otherwise = throwIO ex
+
+-- | @'captureFollowedProcessWith'@ but not acting on the output at all
+--
+-- This /is/ @'readProcessWithExitCode'@, but able to re-use something that was
+-- defined for @'followProcess'@ because of some other use-case.
+--
+captureFollowedProcess
+    :: ((String -> RIO env ()) -> (String -> RIO env ()) -> RIO env ExitCode)
+    -> RIO env (ExitCode, String, String)
+captureFollowedProcess = captureFollowedProcessWith ignore ignore
+  where
+    ignore :: String -> RIO env ()
+    ignore _ = pure ()
+
+-- | Take a @'followProcess'@ and act on and capture its output to a value
+--
+-- This approximates @'readProcessWithExitCode'@ with an added ability to see
+-- the output streams as they happen.
+--
+captureFollowedProcessWith
+    :: (String -> RIO env ())
+    -- ^ Action for @stdout@
+    -> (String -> RIO env ())
+    -- ^ Action for @stderr@
+    -> ( (String -> RIO env ())
+       -> (String -> RIO env ())
+       -> RIO env ExitCode
+       )
+    -- ^ @'followProcess'@-like
+    -> RIO env (ExitCode, String, String)
+captureFollowedProcessWith fOut fErr follow = do
+    outRef <- newIORef []
+    errRef <- newIORef []
+
+    (,,)
+        <$> follow (actAndAppend outRef fOut) (actAndAppend errRef fErr)
+        <*> (unlines <$> readIORef outRef)
+        <*> (unlines <$> readIORef errRef)
+
+actAndAppend :: MonadIO m => IORef [a] -> (a -> m ()) -> a -> m ()
+actAndAppend ref f x = f x <* atomicModifyIORef' ref (\xs -> (xs <> [x], ()))


### PR DESCRIPTION
- Move the `RIO.Process` interface
- Use that to implement a process runner where we can follow output live
- Use that to capture lines of Job output as they happen
- But temporarily ignore them, because we need to migrate a table, etc