### PR TITLE
Bump stylish-haskell to v0.9.2.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ setup.lint:
 setup.tools:
 	stack install $(STACK_ARGUMENTS) --copy-compiler-tool \
 	  fast-tags \
-	  stylish-haskell
+	  stylish-haskell-0.9.2.2
 	@# Need to install brittany from an old resolver and copy it into the
 	@# current resolver's compiler-bin
 	stack --resolver lts-12.26 build --copy-compiler-tool brittany


### PR DESCRIPTION
This fixes stylish-haskell for `BlockArguments` extension.

Not sure if I'm doing this right, so please let me know if I have to update something in other places!