### PR TITLE
Simplify Process.Follow, update LTS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,21 +59,11 @@ jobs:
       - run:
           name: Build
           command: |
-            release_tag=b$CIRCLE_BUILD_NUM
-            release_image=quay.io/restyled-io/restyled.io
-
-            mkdir -p workspace
-            echo "$release_tag" > workspace/release-tag
-            echo "$release_image" > workspace/release-image
-
-            docker build --tag "${release_image}:${release_tag}" .
+            sha=${CIRCLE_SHA1:0:10}
+            release_image=quay.io/restyled-io/restyled.io:$sha
+            docker build --tag "$release_image" .
             docker login -u "$QUAY_USERNAME" -p "$QUAY_PASSWORD" quay.io
-            docker push "${release_image}:${release_tag}"
-      - persist_to_workspace:
-          root: workspace
-          paths:
-            - release-tag
-            - release-image
+            docker push "$release_image"
 
   release:
     docker:
@@ -81,28 +71,26 @@ jobs:
     steps:
       - setup_remote_docker:
          docker_layer_caching: true
-      - attach_workspace:
-          at: /tmp/workspace
       - run:
           name: Release
           command: |
-            read -r release_tag < /tmp/workspace/release-tag
-            read -r release_image < /tmp/workspace/release-image
+            sha=${CIRCLE_SHA1:0:10}
+            release_image=quay.io/restyled-io/restyled.io:$sha
 
             cat >Dockerfile.web <<EOM
-            FROM ${release_image}:${release_tag}
+            FROM $release_image
             CMD ["/app/restyled.io", "web"]
             EOM
 
             cat >Dockerfile.backend <<EOM
-            FROM ${release_image}:${release_tag}
+            FROM $release_image
             CMD ["/app/restyled.io", "backend"]
             EOM
 
             heroku container:login
             heroku container:push --recursive --app restyled-io
             heroku container:release web backend --app restyled-io
-            notify "restyled-io" "Deploy of $release_tag successful"
+            notify "restyled-io" "Deployed at $sha"
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,10 +24,10 @@ jobs:
           command: git ls-files | xargs md5sum > digest
       - restore_cache:
           keys:
-            - v4-{{ .Branch }}-{{ checksum "stack.yaml" }}-{{ checksum "digest" }}
-            - v4-{{ .Branch }}-{{ checksum "stack.yaml" }}-
-            - v4-{{ .Branch }}
-            - v4-
+            - v5-{{ .Branch }}-{{ checksum "stack.yaml" }}-{{ checksum "digest" }}
+            - v5-{{ .Branch }}-{{ checksum "stack.yaml" }}-
+            - v5-{{ .Branch }}
+            - v5-
       - run:
           name: Dependencies
           command: make setup setup.lint
@@ -35,7 +35,7 @@ jobs:
           name: Build
           command: make build
       - save_cache:
-          key: v4-{{ .Branch }}-{{ checksum "stack.yaml" }}-{{ checksum "digest" }}
+          key: v5-{{ .Branch }}-{{ checksum "stack.yaml" }}-{{ checksum "digest" }}
           paths:
             - ~/.stack
             - ./.stack-work

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,10 +6,6 @@ jobs:
     docker:
       - image: fpco/stack-build:lts-13.3
         environment:
-          GIT_AUTHOR_EMAIL: ci@restyled.io
-          GIT_AUTHOR_NAME: Restyled.io CI
-          GIT_COMMITTER_EMAIL: ci@restyled.io
-          GIT_COMMITTER_NAME: Restyled.io CI
           STACK_ARGUMENTS: --no-terminal
       - image: circleci/postgres:9.6.5-alpine
         environment:

--- a/Makefile
+++ b/Makefile
@@ -55,14 +55,9 @@ setup.lint:
 .PHONY: setup.tools
 setup.tools:
 	stack install $(STACK_ARGUMENTS) --copy-compiler-tool \
+	  brittany \
 	  fast-tags \
 	  stylish-haskell
-	@# Need to install brittany from an old resolver and copy it into the
-	@# current resolver's compiler-bin
-	stack --resolver lts-12.26 build --copy-compiler-tool brittany
-	ln -sf \
-	  "$$(stack --resolver lts-12.26 path --compiler-tools-bin)"/brittany \
-	  "$$(stack path --compiler-tools-bin)"/brittany
 
 .PHONY: setup.ngrok
 setup.ngrok:

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,9 @@ build:
 
 .PHONY: lint
 lint:
-	stack exec $(STACK_ARGUMENTS) hlint app src test
+	find app src test -name '*.hs' \
+	  -not -name 'Foundation.hs' \
+	  -exec stack exec $(STACK_ARGUMENTS) hlint {} +
 	# Weeder doesn't work with stack-2.0 :(
 	# stack exec $(STACK_ARGUMENTS) weeder .
 

--- a/Makefile
+++ b/Makefile
@@ -80,8 +80,7 @@ lint:
 	find app src test -name '*.hs' \
 	  -not -name 'Foundation.hs' \
 	  -exec stack exec $(STACK_ARGUMENTS) hlint {} +
-	# Weeder doesn't work with stack-2.0 :(
-	# stack exec $(STACK_ARGUMENTS) weeder .
+	stack exec $(STACK_ARGUMENTS) weeder .
 
 .PHONY: test
 test:

--- a/package.yaml
+++ b/package.yaml
@@ -141,7 +141,6 @@ tests:
     source-dirs: test
     dependencies:
       - restyled
-      - HUnit
       - QuickCheck
       - bytestring
       - filepath

--- a/src/GitHub/Data/AccessTokens.hs
+++ b/src/GitHub/Data/AccessTokens.hs
@@ -15,6 +15,5 @@ data AccessToken = AccessToken
     }
 
 instance FromJSON AccessToken where
-    parseJSON = withObject "GitHub.AccessToken" $ \o -> AccessToken
-        <$> o .: "token"
-        <*> o .: "expires_at"
+    parseJSON = withObject "GitHub.AccessToken"
+        $ \o -> AccessToken <$> o .: "token" <*> o .: "expires_at"

--- a/src/GitHub/Data/Installations.hs
+++ b/src/GitHub/Data/Installations.hs
@@ -13,5 +13,4 @@ newtype Installation = Installation
     }
 
 instance FromJSON Installation where
-    parseJSON = withObject "Installation" $ \o ->
-        Installation <$> o .: "id"
+    parseJSON = withObject "Installation" $ \o -> Installation <$> o .: "id"

--- a/src/GitHub/Endpoints/MarketplaceListing/Plans.hs
+++ b/src/GitHub/Endpoints/MarketplaceListing/Plans.hs
@@ -21,10 +21,8 @@ data MarketplacePlan = MarketplacePlan
     }
 
 instance FromJSON MarketplacePlan where
-    parseJSON = withObject "Plan" $ \o -> MarketplacePlan
-        <$> o .: "id"
-        <*> o .: "name"
-        <*> o .: "description"
+    parseJSON = withObject "Plan" $ \o ->
+        MarketplacePlan <$> o .: "id" <*> o .: "name" <*> o .: "description"
 
 marketplaceListingPlans
     :: AuthMethod am

--- a/src/GitHub/Endpoints/MarketplaceListing/Plans/Accounts.hs
+++ b/src/GitHub/Endpoints/MarketplaceListing/Plans/Accounts.hs
@@ -20,9 +20,8 @@ data MarketplaceAccount = MarketplaceAccount
     }
 
 instance FromJSON MarketplaceAccount where
-    parseJSON = withObject "Account" $ \o -> MarketplaceAccount
-        <$> o .: "id"
-        <*> o .: "login"
+    parseJSON = withObject "Account"
+        $ \o -> MarketplaceAccount <$> o .: "id" <*> o .: "login"
 
 marketplaceListingPlanAccounts
     :: AuthMethod am

--- a/src/GitHub/Endpoints/Repos/Collaborators/Permissions.hs
+++ b/src/GitHub/Endpoints/Repos/Collaborators/Permissions.hs
@@ -36,8 +36,8 @@ newtype CollaboratorPermissions = CollaboratorPermissions
     }
 
 instance FromJSON CollaboratorPermissions where
-    parseJSON = withObject "Permissions" $ \o -> CollaboratorPermissions
-        <$> o .: "permission"
+    parseJSON = withObject "Permissions"
+        $ \o -> CollaboratorPermissions <$> o .: "permission"
 
 collaboratorCanRead :: CollaboratorPermissions -> Bool
 collaboratorCanRead = permissionCanRead . collaboratorPermissionsPermission

--- a/src/GitHub/Request/Preview.hs
+++ b/src/GitHub/Request/Preview.hs
@@ -11,6 +11,8 @@ import Data.Tagged (Tagged(..))
 import GitHub.Data
 import GitHub.Request
 
+-- brittany-disable-next-binding
+
 -- | @'Request'@-like synonym for using @machine-man-preview+json@
 type PreviewRequest k a = GenRequest ('MtPreview MachineManPreviewJson) k a
 

--- a/src/RIO/Process/Follow.hs
+++ b/src/RIO/Process/Follow.hs
@@ -44,7 +44,7 @@ followProcess
     -> (String -> m ()) -- ^ Called with each line of @stderr@
     -> ProcessConfig stdin stdout stderr
     -> m ExitCode
-followProcess fOut fErr pc = withProcess (setPipes pc) $ \p -> do
+followProcess fOut fErr pc = withProcessWait (setPipes pc) $ \p -> do
     aOut <- async $ followPipe (getStdout p) fOut
     aErr <- async $ followPipe (getStderr p) fErr
     ec <- waitExitCode p

--- a/src/RIO/Process/Follow.hs
+++ b/src/RIO/Process/Follow.hs
@@ -1,101 +1,61 @@
 module RIO.Process.Follow
     ( followProcess
-    , captureFollowedProcess
-    , captureFollowedProcessWith
-
-    -- * Minor @"RIO.Process"@ extensions
-    , withExtraEnvVars
     )
 where
 
 import RIO
 
-import qualified Data.Map as Map
 import RIO.Process
 import System.IO (hGetLine)
 import System.IO.Error (isEOFError)
 
--- | Run a process and execute an action on each line of output
+-- | Like @'readProcess', but call an action with each line of output
+--
+-- The actions are run /as output is generated/. This allows (e.g.) capturing
+-- process output to persistent storage in a way that could be (mostly)
+-- re-constructed in order later.
+--
+-- @
+-- 'proc' "sh" ["-c", "echo hi; sleep 3; echo dee >&2; sleep 2; echo ho"]
+--     $ 'followProcess'
+--         (\out -> do
+--             now <- getCurrentTime
+--             insert Log { createdAt = now, stream = "stdout", content = out }
+--         )
+--         (\err -> do
+--             now <- getCurrentTime
+--             insert Log { createdAt = now, stream = "stderr", content = out }
+--         )
+-- @
+--
+-- After this executes, you can expect @Log@ entries such as
+--
+-- @
+-- | createdAt   | stream | content |
+-- |-------------|--------|---------|
+-- | {time  0 }  | stdout | hi      |
+-- | {time ~3s}  | stderr | dee     |
+-- | {time ~5s}  | stdout | ho      |
+-- @
+--
 followProcess
-    :: ( HasLogFunc env
-       , HasProcessContext env
-       , MonadReader env m
-       , MonadUnliftIO m
-       )
-    => FilePath
-    -- ^ Command
-    -> [String]
-    -- ^ Arguments
-    -> (String -> m ())
-    -- ^ Called with each line of @stdout@
-    -> (String -> m ())
-    -- ^ Called with each line of @stderr@
+    :: MonadUnliftIO m
+    => (String -> m ()) -- ^ Called with each line of @stdout@
+    -> (String -> m ()) -- ^ Called with each line of @stderr@
+    -> ProcessConfig stdin stdout stderr
     -> m ExitCode
-followProcess cmd args fOut fErr = proc cmd args $ \pc ->
-    withProcess (setPipes pc) $ \p -> do
-        aOut <- async $ followPipe (getStdout p) fOut
-        aErr <- async $ followPipe (getStderr p) fErr
-        ec <- waitExitCode p
-        ec <$ traverse_ wait [aOut, aErr]
+followProcess fOut fErr pc = withProcess (setPipes pc) $ \p -> do
+    aOut <- async $ followPipe (getStdout p) fOut
+    aErr <- async $ followPipe (getStderr p) fErr
+    ec <- waitExitCode p
+    ec <$ traverse_ wait [aOut, aErr]
 
 setPipes :: ProcessConfig stdin stdout stderr -> ProcessConfig () Handle Handle
 setPipes = setStdin closed . setStdout createPipe . setStderr createPipe
 
 followPipe :: MonadUnliftIO m => Handle -> (String -> m ()) -> m ()
-followPipe hdl act = loop `catch` handleEOF
+followPipe h act = handle handleEOF $ forever $ act =<< liftIO (hGetLine h)
   where
-    loop = do
-        ln <- liftIO $ hGetLine hdl
-        act ln
-        followPipe hdl act
-
     handleEOF ex
         | isEOFError ex = pure ()
         | otherwise = throwIO ex
-
--- | @'captureFollowedProcessWith'@ but not acting on the output at all
---
--- This /is/ @'readProcessWithExitCode'@, but able to re-use something that was
--- defined for @'followProcess'@ because of some other use-case.
---
-captureFollowedProcess
-    :: MonadIO m
-    => ((String -> m ()) -> (String -> m ()) -> m ExitCode)
-    -> m (ExitCode, String, String)
-captureFollowedProcess = captureFollowedProcessWith ignore ignore
-
-ignore :: Applicative f => a -> f ()
-ignore _ = pure ()
-
--- | Take a @'followProcess'@ and act on and capture its output to a value
---
--- This approximates @'readProcessWithExitCode'@ with an added ability to see
--- the output streams as they happen.
---
-captureFollowedProcessWith
-    :: MonadIO m
-    => (String -> m ())
-    -- ^ Action for @stdout@
-    -> (String -> m ())
-    -- ^ Action for @stderr@
-    -> ((String -> m ()) -> (String -> m ()) -> m ExitCode)
-    -- ^ @'followProcess'@-like
-    -> m (ExitCode, String, String)
-captureFollowedProcessWith fOut fErr follow = do
-    outRef <- newIORef []
-    errRef <- newIORef []
-
-    (,,)
-        <$> follow (actAndAppend outRef fOut) (actAndAppend errRef fErr)
-        <*> (unlines <$> readIORef outRef)
-        <*> (unlines <$> readIORef errRef)
-
-actAndAppend :: MonadIO m => IORef [a] -> (a -> m ()) -> a -> m ()
-actAndAppend ref f x = f x <* atomicModifyIORef' ref (\xs -> (xs <> [x], ()))
-
-withExtraEnvVars
-    :: (HasProcessContext env, MonadReader env m, MonadIO m)
-    => [(Text, Text)]
-    -> m a
-    -> m a
-withExtraEnvVars envs = withModifyEnvVars $ Map.union (Map.fromList envs)

--- a/src/Restyled/Admin/RepoSearch.hs
+++ b/src/Restyled/Admin/RepoSearch.hs
@@ -36,7 +36,7 @@ searchRepos limit q = runDB $ do
         then count $ searchFilters q
         else pure $ length repos
 
-    pure SearchResults {srRepos = repos, srTotal = total}
+    pure SearchResults { srRepos = repos, srTotal = total }
 
 searchFilters :: Text -> [Filter Repo]
 searchFilters q = [RepoOwner `ilike` q] ||. [RepoName `ilike` q]

--- a/src/Restyled/Backend/Foundation.hs
+++ b/src/Restyled/Backend/Foundation.hs
@@ -20,24 +20,22 @@ data Backend = Backend
     }
 
 instance HasLogFunc Backend where
-    logFuncL = lens backendLogFunc $ \x y -> x
-        { backendLogFunc = y }
+    logFuncL = lens backendLogFunc $ \x y -> x { backendLogFunc = y }
 
 instance HasSettings Backend where
-    settingsL = lens backendSettings $ \x y -> x
-        { backendSettings = y }
+    settingsL = lens backendSettings $ \x y -> x { backendSettings = y }
 
 instance HasProcessContext Backend where
-    processContextL = lens backendProcessContext $ \x y -> x
-        { backendProcessContext = y }
+    processContextL =
+        lens backendProcessContext $ \x y -> x { backendProcessContext = y }
 
 instance HasDB Backend where
-    dbConnectionPoolL = lens backendConnPool $ \x y -> x
-        { backendConnPool = y }
+    dbConnectionPoolL =
+        lens backendConnPool $ \x y -> x { backendConnPool = y }
 
 instance HasRedis Backend where
-    redisConnectionL = lens backendRedisConn $ \x y -> x
-        { backendRedisConn = y }
+    redisConnectionL =
+        lens backendRedisConn $ \x y -> x { backendRedisConn = y }
 
 loadBackend :: AppSettings -> IO Backend
 loadBackend settings@AppSettings {..} = do

--- a/src/Restyled/Foundation.hs
+++ b/src/Restyled/Foundation.hs
@@ -60,6 +60,8 @@ mkYesodData "App" $(parseRoutesFile "config/routes")
 
 type Form x = Html -> MForm (HandlerFor App) (FormResult x, Widget)
 
+-- brittany-disable-next-binding
+
 instance Yesod App where
     approot = ApprootMaster $ appRoot . view settingsL
 
@@ -175,6 +177,8 @@ instance YesodPersist App where
     runDB = runDB
 
 instance YesodAuthPersist App
+
+-- brittany-disable-next-binding
 
 instance YesodAuth App where
     type AuthId App = UserId

--- a/src/Restyled/Handlers/Admin/Jobs.hs
+++ b/src/Restyled/Handlers/Admin/Jobs.hs
@@ -14,7 +14,7 @@ import Restyled.Yesod
 data JobSummary = JobSummary (Route App -> Text) (Entity Job)
 
 instance ToJSON JobSummary where
-    toJSON (JobSummary urlRender (Entity jobId Job{..})) = object
+    toJSON (JobSummary urlRender (Entity jobId Job {..})) = object
         [ "created" .= jobCreatedAt
         , "repoPull" .= repoPullPath jobOwner jobRepo jobPullRequest
         , "exitCode" .= jobExitCode

--- a/src/Restyled/Settings/Display.hs
+++ b/src/Restyled/Settings/Display.hs
@@ -1,5 +1,3 @@
-{-# OPTIONS_GHC -fno-warn-deprecations #-}
-
 module Restyled.Settings.Display
     ( displayAppSettings
     )
@@ -43,7 +41,6 @@ displayRedisURL ConnInfo {..} = "redis://" <> user <> rest
         ]
 
 displayPortID :: PortID -> String
-displayPortID (Service s) = s
 displayPortID (PortNumber p) = show p
 displayPortID (UnixSocket s) = s
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,16 +1,10 @@
----
-resolver: lts-13.24
+resolver: lts-14.6
 extra-deps:
   - envparse-0.4.1@sha256:989902e6368532548f61de1fa245ad2b39176cddd8743b20071af519a709ce30
   - github-0.22@sha256:13f09e904248a40dd173c08f2859d0dfda178a7c27f88df20b70a0d5a7614757
-  - jwt-0.10.0@sha256:d14551b0c357424fb9441ec9a7a9d5b90b13f805fcc9327ba49db548cd64fc29
-  - yesod-paginator-1.1.0.2@sha256:f21d30b5a02e23a5ff65461cef6a1ca1c6c26700b8fa4013d5114c3291d7a9ed
 
   # for github-0.22
-  - binary-instances-1@sha256:e7768b92f34bc40cc5cabecc5c143dee6ab4bcb5eb441d58e15a0b000d64940b
-  - binary-orphans-1.0.1@sha256:74d9a8e2c8c4dc8e11c9028ef103b930fc62f3943e45b1629f39114f2bfb5abb
-  - time-compat-1.9.2.2@sha256:9998dc1b77b5067572ab708e94750f1061152f342e92ad1aba38aae63581174d
-  - unordered-containers-0.2.10.0@sha256:5e9b095a9283d9e2f064fec73a81a6b6ea0b7fda3f219a8175785d2d2a3de204
+  - binary-instances-1@sha256:b17565598b8df3241f9b46fa8e3a3368ecc8e3f2eb175d7c28f319042a6f5c79,2613
 
   # for dbmigrations-postgresql
   - HDBC-postgresql-2.3.2.6@sha256:6e1636b0414ae7b028a01f1a90cf3e28c14f1df7867cf2615d5357d9abcd6279
@@ -18,5 +12,9 @@ extra-deps:
   - dbmigrations-2.0.0@sha256:1e3bd62ca980659d27b6bc7b00e58ae0e2bf7781e3859f440b7c005c46037075
   - yaml-light-0.1.4@sha256:838b509c3a895339eea42b6524f46ba4e59c33e9f43537123cdaedfea09ca58d
 
+# Makes weeder work in stack-2
 ghc-options:
-  "$locals": -fhide-source-paths
+  "$locals":
+    -ddump-to-file
+    -ddump-hi
+    -fignore-optim-changes

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -19,47 +19,12 @@ packages:
   original:
     hackage: github-0.22@sha256:13f09e904248a40dd173c08f2859d0dfda178a7c27f88df20b70a0d5a7614757
 - completed:
-    hackage: jwt-0.10.0@sha256:d14551b0c357424fb9441ec9a7a9d5b90b13f805fcc9327ba49db548cd64fc29,4180
-    pantry-tree:
-      size: 1027
-      sha256: e0cf95e834d99768ad8a3f7e99246948f0cdd2cfa18813517f540144aea6c3e5
-  original:
-    hackage: jwt-0.10.0@sha256:d14551b0c357424fb9441ec9a7a9d5b90b13f805fcc9327ba49db548cd64fc29
-- completed:
-    hackage: yesod-paginator-1.1.0.2@sha256:f21d30b5a02e23a5ff65461cef6a1ca1c6c26700b8fa4013d5114c3291d7a9ed,2321
-    pantry-tree:
-      size: 874
-      sha256: eae0d33669d8568ac7b77dee35f9e0dac846e7c2f5e561b757b544e7844534d5
-  original:
-    hackage: yesod-paginator-1.1.0.2@sha256:f21d30b5a02e23a5ff65461cef6a1ca1c6c26700b8fa4013d5114c3291d7a9ed
-- completed:
-    hackage: binary-instances-1@sha256:e7768b92f34bc40cc5cabecc5c143dee6ab4bcb5eb441d58e15a0b000d64940b,2591
+    hackage: binary-instances-1@sha256:b17565598b8df3241f9b46fa8e3a3368ecc8e3f2eb175d7c28f319042a6f5c79,2613
     pantry-tree:
       size: 1035
-      sha256: e0425d75675a23270bdf570faee30edb28d3f19ba45e166b4ce1725a7b778043
+      sha256: 938ffc6990cac12681c657f7afa93737eecf335e6f0212d8c0b7c1ea3e0f40f4
   original:
-    hackage: binary-instances-1@sha256:e7768b92f34bc40cc5cabecc5c143dee6ab4bcb5eb441d58e15a0b000d64940b
-- completed:
-    hackage: binary-orphans-1.0.1@sha256:74d9a8e2c8c4dc8e11c9028ef103b930fc62f3943e45b1629f39114f2bfb5abb,1987
-    pantry-tree:
-      size: 285
-      sha256: e18cc1489df82d71535e1a15218142ad74199c11c91a5cac7dadf9ddb362fdc2
-  original:
-    hackage: binary-orphans-1.0.1@sha256:74d9a8e2c8c4dc8e11c9028ef103b930fc62f3943e45b1629f39114f2bfb5abb
-- completed:
-    hackage: time-compat-1.9.2.2@sha256:9998dc1b77b5067572ab708e94750f1061152f342e92ad1aba38aae63581174d,4209
-    pantry-tree:
-      size: 3602
-      sha256: 724a63e80871bc6709a2d3ca1c3c7316048e99c9d50b0492f0eff25ce2cecbe0
-  original:
-    hackage: time-compat-1.9.2.2@sha256:9998dc1b77b5067572ab708e94750f1061152f342e92ad1aba38aae63581174d
-- completed:
-    hackage: unordered-containers-0.2.10.0@sha256:5e9b095a9283d9e2f064fec73a81a6b6ea0b7fda3f219a8175785d2d2a3de204,5199
-    pantry-tree:
-      size: 1415
-      sha256: dfc2d75f4e59c03e2c68be6909b577f26991367134eaac06a407e940e66856ae
-  original:
-    hackage: unordered-containers-0.2.10.0@sha256:5e9b095a9283d9e2f064fec73a81a6b6ea0b7fda3f219a8175785d2d2a3de204
+    hackage: binary-instances-1@sha256:b17565598b8df3241f9b46fa8e3a3368ecc8e3f2eb175d7c28f319042a6f5c79,2613
 - completed:
     hackage: HDBC-postgresql-2.3.2.6@sha256:6e1636b0414ae7b028a01f1a90cf3e28c14f1df7867cf2615d5357d9abcd6279,3164
     pantry-tree:
@@ -90,7 +55,7 @@ packages:
     hackage: yaml-light-0.1.4@sha256:838b509c3a895339eea42b6524f46ba4e59c33e9f43537123cdaedfea09ca58d
 snapshots:
 - completed:
-    size: 498402
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/13/24.yaml
-    sha256: 33e96adfe24f112b62f6edd22565cdbaa13155703bbfbfdc3d0a9bc6138ae7bf
-  original: lts-13.24
+    size: 524127
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/6.yaml
+    sha256: dc70dfb45e2c32f54719819bd055f46855dd4b3bd2e58b9f3f38729a2d553fbb
+  original: lts-14.6

--- a/test/Restyled/Backend/RestyleMachineSpec.hs
+++ b/test/Restyled/Backend/RestyleMachineSpec.hs
@@ -1,0 +1,30 @@
+module Restyled.Backend.RestyleMachineSpec
+    ( spec
+    )
+where
+
+import RIO
+
+import Restyled.Backend.RestyleMachine
+import RIO.Process
+import Test.Hspec
+
+spec :: Spec
+spec = do
+    describe "withExtraEnvVars" $ do
+        it "appends extra ENV vars to the Process Context" $ do
+            output <-
+                withProcessContextNoLogging
+                $ withExtraEnvVars [("FOO", "1")]
+                $ proc "sh" ["-c", "echo $FOO"] readProcessStdout_
+
+            output `shouldBe` "1\n"
+
+        it "overrides ENV vars that already exist" $ do
+            output <-
+                withProcessContextNoLogging
+                $ withExtraEnvVars [("FOO", "1")]
+                $ withExtraEnvVars [("FOO", "2")]
+                $ proc "sh" ["-c", "echo $FOO"] readProcessStdout_
+
+            output `shouldBe` "2\n"

--- a/test/Restyled/Test/Lens.hs
+++ b/test/Restyled/Test/Lens.hs
@@ -1,7 +1,5 @@
 module Restyled.Test.Lens
-    ( entityKeyLens
-    , entityValLens
-    , fieldLens
+    ( fieldLens
     , (.~)
     , (?~)
     , (^.)
@@ -15,12 +13,6 @@ import Restyled.Prelude hiding (fieldLens)
 import Control.Lens ((.~), (?~), (^..), (^?))
 import qualified Database.Persist as P
 
-entityKeyLens :: Lens' (Entity record) (Key record)
-entityKeyLens = lens entityKey (\(Entity _ v) k -> Entity k v)
-
-entityValLens :: Lens' (Entity record) record
-entityValLens = lens entityVal (\(Entity k _) v -> Entity k v)
-
 fieldLens
     :: PersistEntity record => EntityField record field -> Lens' record field
 fieldLens field =
@@ -30,3 +22,9 @@ unsafeEntityLens :: Lens' record (Entity record)
 unsafeEntityLens = lens (Entity (error err)) (\_ entity -> entityVal entity)
   where
     err = "Cannot access EntityKey of Entity constructed unsafely without one"
+
+-- entityKeyLens :: Lens' (Entity record) (Key record)
+-- entityKeyLens = lens entityKey (\(Entity _ v) k -> Entity k v)
+
+entityValLens :: Lens' (Entity record) record
+entityValLens = lens entityVal (\(Entity k _) v -> Entity k v)

--- a/test/Restyled/Widgets/ContainsURLsSpec.hs
+++ b/test/Restyled/Widgets/ContainsURLsSpec.hs
@@ -38,11 +38,9 @@ newtype Parsed = Parsed ContainsURLs
 instance Arbitrary Parsed where
     arbitrary = do
         n <- getPositive <$> arbitrary
-
-        Parsed . ContainsURLs . spaced . take n <$> oneof
-            [ alternating contentPart urlPart
-            , alternating urlPart contentPart
-            ]
+        parts <- oneof
+            [alternating contentPart urlPart, alternating urlPart contentPart]
+        pure $ Parsed $ ContainsURLs $ spaced $ take n parts
 
 -- | Add a leading space to any @'ContentPart'@ after a @'URLPart'@
 --


### PR DESCRIPTION
```
8284334 (patrick brisbin, 12 minutes ago)

   Install real Brittany now

694ad80 (patrick brisbin, 9 minutes ago)
   Re-enable weeder

d66e569 (patrick brisbin, 12 minutes ago)
   Fix make lint

   HLint now chokes (Parse Error) on TH in Foundation.hs. Unclear why, but 
   this expression seems to be the only way to express it. HLint ignore 
   pragmas still error, presumably because parse happens before ignore.

922bb1e (patrick brisbin, 12 minutes ago)
   Update LTS

   - Remove unnecessary extra-deps
   - Make weeder-2.0 work again

e751ec8 (patrick brisbin, 12 hours ago)
   Vastly simplify RIO.Process.Follow

   Implement the following function in a much more idiomatic style, which is
   to accept a ProcessConfig argument, instead of actually calling proc 
   internally and therefore having to live in an RIO env ourselves.

   This composes much better and allows followProcess to be used 
   interchangeably with other analogous functions, such as readProcess.

   Similarly, instead of owning running something on a RestyleMachine, and 
   therefore needing to call proc, and therefore needing that un-idiomatic 
   interface, simplify that function to just ENV-modification, which is all it
   should be. This lead us to moving our (tested) helper and perhaps a 
   muddier-than-necessary diff, but oh well.

   Together, all of this means our "capture" versions are unnecessary and we
   can just use readProcess when that's what we need or followProcess when
   that's what we want. :chefs_kiss:
```