### PR TITLE
Add /system/metrics

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,9 @@ jobs:
             aws cloudformation update-stack \
               --stack-name prod-services \
               --use-previous-template \
+              --parameter "ParameterKey=Environment,UsePreviousValue=true" \
+              --parameter "ParameterKey=RestylerImage,UsePreviousValue=true" \
+              --parameter "ParameterKey=AppsWebhooksDesiredCount,UsePreviousValue=true" \
               --parameter "ParameterKey=RestyledImage,ParameterValue=$image" \
               --capabilities CAPABILITY_NAMED_IAM
             aws cloudformation wait stack-update-complete \

--- a/config/routes
+++ b/config/routes
@@ -51,3 +51,7 @@
   /tokens AdminTokensP:
     / AdminTokensR GET POST
     /#ApiTokenId AdminTokenR DELETE
+
+/system SystemP:
+  /metrics SystemMetricsP:
+    / SystemMetricsR GET

--- a/src/Restyled/Application.hs
+++ b/src/Restyled/Application.hs
@@ -29,6 +29,7 @@ import Restyled.Handlers.Marketplace
 import Restyled.Handlers.PrivacyPolicy
 import Restyled.Handlers.Profile
 import Restyled.Handlers.Repos
+import Restyled.Handlers.System.Metrics
 import Restyled.Handlers.Thanks
 import Restyled.Handlers.Webhooks
 import Restyled.Settings

--- a/src/Restyled/Foundation.hs
+++ b/src/Restyled/Foundation.hs
@@ -108,6 +108,10 @@ instance Yesod App where
         settings <- getsYesod $ view settingsL
         runDB $ authorizeRepo settings owner repo =<< maybeAuthId
 
+    isAuthorized (SystemP _) _ = do
+        settings <- getsYesod $ view settingsL
+        runDB $ authorizeAdmin settings =<< maybeAuthId
+
     addStaticContent ext mime content = do
         staticDir <- getsYesod $ appStaticDir . view settingsL
 

--- a/src/Restyled/Handlers/System/Metrics.hs
+++ b/src/Restyled/Handlers/System/Metrics.hs
@@ -1,0 +1,64 @@
+module Restyled.Handlers.System.Metrics
+    ( getSystemMetricsR
+    )
+where
+
+import Restyled.Prelude
+
+import Data.Semigroup (Sum(..))
+import qualified Restyled.Backend.Webhook as Webhook
+import Restyled.Foundation
+import Restyled.Metrics
+import Restyled.TimeRange
+
+data Metric n = Metric
+    { mName :: Text
+    , mValue :: n
+    , mUnit :: Unit
+    }
+
+metric :: Text -> n -> Metric n
+metric = metricUnit Count
+
+metricUnit :: Unit -> Text -> n -> Metric n
+metricUnit unit name value =
+    Metric { mName = name, mValue = value, mUnit = unit }
+
+instance ToJSON n => ToJSON (Metric n) where
+    toJSON Metric {..} =
+        object ["MetricName" .= mName, "Value" .= mValue, "Unit" .= mUnit]
+
+data Unit = Count | Percent
+
+instance ToJSON Unit where
+    toJSON Count = String "Count"
+    toJSON Percent = String "Percent"
+
+getSystemMetricsR :: Handler Value
+getSystemMetricsR = do
+    depth <- runRedis Webhook.queueDepth
+    range <- timeRangeFromMinutesAgo 5
+    jobMetrics <- runDB $ jmbhJobMetrics <$$> fetchJobMetricsByHour range
+
+    let JobMetrics {..} = mconcat jobMetrics
+
+        succeeded = getSum jmSucceeded
+        failed = getSum jmFailed
+        unfinished = getSum jmUnfinished
+        completed = succeeded + failed
+
+        successPercent :: Double
+        successPercent
+            | completed == 0 = 0
+            | otherwise = fromIntegral succeeded / fromIntegral completed
+
+    pure $ object
+        [ "range" .= range
+        , "metrics" .= toJSON
+            [ toJSON $ metric "QueueDepth" depth
+            , toJSON $ metric "JobsSucceeded" succeeded
+            , toJSON $ metric "JobsFailed" failed
+            , toJSON $ metric "JobsUnfinished" unfinished
+            , toJSON $ metricUnit Percent "JobsSuccessRate" successPercent
+            ]
+        ]

--- a/src/Restyled/Metrics.hs
+++ b/src/Restyled/Metrics.hs
@@ -26,6 +26,9 @@ data JobMetrics = JobMetrics
 instance Semigroup JobMetrics where
     (<>) = gmappend
 
+instance Monoid JobMetrics where
+    mempty = gmempty
+
 data JobMetricsByHour = JobMetricsByHour
     { jmbhEpoch :: Int
     , jmbhJobMetrics :: JobMetrics

--- a/src/Restyled/TimeRange.hs
+++ b/src/Restyled/TimeRange.hs
@@ -26,6 +26,9 @@ data TimeRange = TimeRange
     , tmTo :: UTCTime
     }
 
+instance ToJSON TimeRange where
+    toJSON TimeRange {..} = object ["from" .= tmFrom, "to" .= tmTo]
+
 timeRangeFromMinutesAgo :: MonadIO m => Int -> m TimeRange
 timeRangeFromMinutesAgo minutes = do
     now <- getCurrentTime


### PR DESCRIPTION
Returns various system metrics, in a format suitable for shuttling to CloudWatch
(e.g. via our record-metrics Lambda). This will replace our Health task, once
that lambda is updated and CloudWatch Alarms are added.