### PR TITLE
Extend support for non-GitHub Plans

### DIFF
--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -20,4 +20,6 @@ restylers:
       include:
         - "**/*.js"
         - "**/*.julius"
+  - shellharden:
+      enabled: false
   - "*"

--- a/config/models
+++ b/config/models
@@ -71,11 +71,12 @@ RestyleMachine json
   deriving Eq Show
 
 MarketplacePlan json
-  githubId Int
+  githubId Int Maybe
   name Text
   description Text
+  privateRepoAllowance PrivateRepoAllowance
 
-  UniqueMarketplacePlan githubId
+  UniqueMarketplacePlan githubId !force
   deriving Eq Show
 
 MarketplaceAccount json

--- a/db/migrate-new
+++ b/db/migrate-new
@@ -28,7 +28,8 @@ path=$DBM_MIGRATION_STORE/$name.txt
 stack exec -- moo-postgresql new "$name"
 
 {
-  echo '# vim: ft=yaml'
+  # don't confuse vim itself
+  printf '# %s ft=yaml\n' 'vim:'
   sed 's/^\(Description:\).*$/\1 '"$description"'/' "$path"
 } | sponge "$path"
 

--- a/db/migrations/add-marketplace-plan-private-repo-allowance.txt
+++ b/db/migrations/add-marketplace-plan-private-repo-allowance.txt
@@ -1,0 +1,19 @@
+# vim: ft=yaml
+Description: Add marketplace_plan.private_repo_allowance
+Created: 2020-10-05 15:32:17.648648347 UTC
+Depends: migrate-plans create-marketplace-plan
+Apply: |
+  ALTER TABLE marketplace_plan
+    ADD COLUMN private_repo_allowance integer;
+
+  UPDATE marketplace_plan
+    SET private_repo_allowance = -1
+    WHERE github_id IN (0, 2178, 2553, 3240);
+
+  UPDATE marketplace_plan
+    SET private_repo_allowance = 1
+    WHERE github_id = 2695;
+
+Revert: |
+  ALTER TABLE marketplace_plan
+    DROP COLUMN private_repo_allowance integer

--- a/db/migrations/migrate-plans.txt
+++ b/db/migrations/migrate-plans.txt
@@ -1,7 +1,7 @@
 # vim: ft=yaml
 Description: Migration old plan records to marketplace_account
 Created: 2019-03-22 19:49:21.393490067 UTC
-Depends: add-marketplace-account create-marketplace-plan
+Depends: create-plan add-marketplace-account create-marketplace-plan
 Apply: |
   INSERT INTO marketplace_plan
     (github_id, name, description) VALUES

--- a/db/migrations/null-marketplace-plan-github-d.txt
+++ b/db/migrations/null-marketplace-plan-github-d.txt
@@ -1,0 +1,14 @@
+# vim: ft=yaml
+Description: Null marketplace_plan.githubId
+Created: 2020-10-05 15:26:41.746241895 UTC
+Depends: migrate-plans create-marketplace-plan
+Apply: |
+  ALTER TABLE marketplace_plan
+    ALTER COLUMN github_id DROP NOT NULL
+Revert: |
+  UPDATE marketplace_plan
+  SET github_id = 0
+  WHERE github_id IS NULL;
+
+  ALTER TABLE marketplace_plan
+    ALTER COLUMN github_id SET NOT NULL

--- a/restyled.cabal
+++ b/restyled.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 330affaad3379d06f495934b18aa3d9cc392d7864e780935b6740df95b0a100f
+-- hash: 49853c5935119c11a0d2b550357c52c3356fcb6973dd2613ce269d26869c3614
 
 name:           restyled
 version:        0.1.1.0
@@ -80,6 +80,7 @@ library
       Restyled.Prelude
       Restyled.Prelude.Esqueleto
       Restyled.PrivateRepoAllowance
+      Restyled.PrivateRepoEnabled
       Restyled.Routes
       Restyled.Settings
       Restyled.StreamJobLogLines

--- a/src/Restyled/Backend/DiscountMarketplacePlan.hs
+++ b/src/Restyled/Backend/DiscountMarketplacePlan.hs
@@ -9,6 +9,7 @@ where
 import Restyled.Prelude
 
 import Restyled.Models
+import Restyled.PrivateRepoAllowance
 
 fetchDiscountMarketplacePlan
     :: MonadIO m => SqlPersistT m (Entity MarketplacePlan)
@@ -19,7 +20,8 @@ fetchDiscountMarketplacePlan = upsert
     ]
   where
     plan@MarketplacePlan {..} = MarketplacePlan
-        { marketplacePlanGithubId = 0
+        { marketplacePlanGithubId = Nothing
+        , marketplacePlanPrivateRepoAllowance = PrivateRepoAllowanceUnlimited
         , marketplacePlanName = "Friends & Family"
         , marketplacePlanDescription = "Manually managed discount plan"
         }

--- a/src/Restyled/Handlers/Admin/Marketplace.hs
+++ b/src/Restyled/Handlers/Admin/Marketplace.hs
@@ -72,8 +72,14 @@ getAdminMarketplacePlansR = do
         intField
         "githubId"
 
+    let
+        -- Pass githubId=-1 to query for non-GH Plans. TODO: Custom Field?
+        githubId = case mpqGitHubId of
+            -1 -> Nothing
+            x -> Just x
+
     runDB $ toJSON <$> selectList
-        [MarketplacePlanGithubId ==. mpqGitHubId]
+        [MarketplacePlanGithubId ==. githubId]
         [Asc MarketplacePlanName]
 
 newtype MarketplaceAccountsQuery = MarketplaceAccountsQuery

--- a/src/Restyled/Handlers/Marketplace.hs
+++ b/src/Restyled/Handlers/Marketplace.hs
@@ -9,7 +9,7 @@ import Restyled.Prelude
 import Restyled.ApiError
 import Restyled.Foundation
 import Restyled.Models
-import Restyled.PrivateRepoAllowance
+import Restyled.PrivateRepoEnabled
 import Restyled.Yesod
 
 postRepoMarketplaceClaimR :: OwnerName -> RepoName -> Handler TypedContent

--- a/src/Restyled/Handlers/Profile.hs
+++ b/src/Restyled/Handlers/Profile.hs
@@ -99,7 +99,7 @@ getMarketplaceAction GitHubIdentity {..} (Entity repoId Repo {..}) = do
 
 isLimitedPlan :: Entity MarketplacePlan -> Bool
 isLimitedPlan (Entity _ MarketplacePlan {..}) =
-    case privateRepoAllowance marketplacePlanGithubId of
+    case marketplacePlanPrivateRepoAllowance of
         PrivateRepoAllowanceNone -> False
         PrivateRepoAllowanceUnlimited -> False
         PrivateRepoAllowanceLimited _ -> True

--- a/src/Restyled/Models/DB.hs
+++ b/src/Restyled/Models/DB.hs
@@ -13,6 +13,7 @@ import Restyled.Prelude
 
 import Database.Persist.Quasi
 import Database.Persist.TH
+import Restyled.PrivateRepoAllowance
 
 mkPersist sqlSettings $(persistFileWith lowerCaseSettings "config/models")
 

--- a/src/Restyled/PrivateRepoAllowance.hs
+++ b/src/Restyled/PrivateRepoAllowance.hs
@@ -1,123 +1,40 @@
 module Restyled.PrivateRepoAllowance
     ( PrivateRepoAllowance(..)
-    , privateRepoAllowance
-
-    -- * Enable/disable
-    , PrivateRepoEnabled(..)
-    , enableMarketplaceRepo
-    , enableMarketplaceRepoForUser
-    , disableMarketplaceRepoForUser
     )
 where
 
 import Restyled.Prelude
 
-import Data.List (genericLength)
-import Restyled.Models
-
-data PrivateRepoEnabled
-    = PrivateRepoEnabled
-    | PrivateRepoNotAllowed
-    | PrivateRepoLimited
-
-enableMarketplaceRepo
-    :: MonadIO m => Entity Repo -> SqlPersistT m (Maybe PrivateRepoEnabled)
-enableMarketplaceRepo (Entity repoId repo) = runMaybeT $ do
-    account <- fetchMarketplaceAccountForRepoT repo
-    enableMarketplaceRepoIdForAccountT repoId account
-
-enableMarketplaceRepoForUser
-    :: MonadIO m
-    => Entity Repo
-    -> Entity User
-    -> SqlPersistT m (Maybe PrivateRepoEnabled)
-enableMarketplaceRepoForUser repo@(Entity repoId _) user = runMaybeT $ do
-    account <- fetchMarketplaceAccountForRepoUserT repo user
-    enableMarketplaceRepoIdForAccountT repoId account
-
-enableMarketplaceRepoIdForAccountT
-    :: MonadIO m
-    => RepoId
-    -> Entity MarketplaceAccount
-    -> MaybeT (SqlPersistT m) PrivateRepoEnabled
-enableMarketplaceRepoIdForAccountT repoId (Entity accountId account) = do
-    Entity planId plan <- getEntityT $ marketplaceAccountMarketplacePlan account
-
-    lift
-        $ enableMarketplaceRepoForPlan planId accountId repoId
-        $ privateRepoAllowance
-        $ marketplacePlanGithubId plan
-
-enableMarketplaceRepoForPlan
-    :: MonadIO m
-    => MarketplacePlanId
-    -> MarketplaceAccountId
-    -> RepoId
-    -> PrivateRepoAllowance
-    -> SqlPersistT m PrivateRepoEnabled
-enableMarketplaceRepoForPlan planId accountId repoId = \case
-    PrivateRepoAllowanceNone -> pure PrivateRepoNotAllowed
-    PrivateRepoAllowanceUnlimited -> pure PrivateRepoEnabled
-    PrivateRepoAllowanceLimited limit -> do
-        enabledRepoIds <-
-            marketplaceEnabledRepoRepo
-            . entityVal
-            <$$> selectList
-                     [ MarketplaceEnabledRepoMarketplacePlan ==. planId
-                     , MarketplaceEnabledRepoMarketplaceAccount ==. accountId
-                     ]
-                     []
-
-        result <- checkEnabledRepos enabledRepoIds limit
-        pure $ if result then PrivateRepoEnabled else PrivateRepoLimited
-  where
-    checkEnabledRepos enabledRepoIds limit
-        | repoId `elem` enabledRepoIds = pure True
-        | genericLength enabledRepoIds >= limit = pure False
-        | otherwise = True <$ insert MarketplaceEnabledRepo
-            { marketplaceEnabledRepoMarketplacePlan = planId
-            , marketplaceEnabledRepoMarketplaceAccount = accountId
-            , marketplaceEnabledRepoRepo = repoId
-            }
-
-disableMarketplaceRepoForUser
-    :: MonadIO m => Entity Repo -> Entity User -> SqlPersistT m ()
-disableMarketplaceRepoForUser repo user = void $ runMaybeT $ do
-    account <- fetchMarketplaceAccountForRepoUserT repo user
-    plan <- getEntityT $ marketplaceAccountMarketplacePlan $ entityVal account
-    lift $ deleteWhere
-        [ MarketplaceEnabledRepoMarketplacePlan ==. entityKey plan
-        , MarketplaceEnabledRepoMarketplaceAccount ==. entityKey account
-        , MarketplaceEnabledRepoRepo ==. entityKey repo
-        ]
-
-fetchMarketplaceAccountForRepoUserT
-    :: MonadIO m
-    => Entity Repo
-    -> Entity User
-    -> MaybeT (SqlPersistT m) (Entity MarketplaceAccount)
-fetchMarketplaceAccountForRepoUserT repo user = do
-    repoAccount <- fetchMarketplaceAccountForRepoT $ entityVal repo
-    userAccount <- fetchMarketplaceAccountForUserT $ entityVal user
-    userAccount <$ guard (userAccount == repoAccount)
+import Database.Persist.Sql (PersistFieldSql(..))
 
 data PrivateRepoAllowance
     = PrivateRepoAllowanceNone
     | PrivateRepoAllowanceUnlimited
     | PrivateRepoAllowanceLimited Natural
+    deriving stock (Eq, Show)
 
-privateRepoAllowance :: Int -> PrivateRepoAllowance
-privateRepoAllowance = \case
-    -- Manually-managed "Friends & Family" plan
-    0 -> PrivateRepoAllowanceUnlimited
-    -- Temporary "Early Adopter" plan
-    2178 -> PrivateRepoAllowanceUnlimited
-    -- "Unlimited" private repo plan
-    2553 -> PrivateRepoAllowanceUnlimited
-    -- "Unlimited" private repo plan, newly priced
-    3240 -> PrivateRepoAllowanceUnlimited
-    -- "Solo", single private repo plan
-    2695 -> PrivateRepoAllowanceLimited 1
+fromNumeric :: Int -> PrivateRepoAllowance
+fromNumeric n
+    | n == 0 = PrivateRepoAllowanceNone
+    | n < 0 = PrivateRepoAllowanceUnlimited
+    | otherwise = PrivateRepoAllowanceLimited $ fromIntegral n
 
-    -- All other plans
-    _ -> PrivateRepoAllowanceNone
+toNumeric :: PrivateRepoAllowance -> Int
+toNumeric = \case
+    PrivateRepoAllowanceNone -> 0
+    PrivateRepoAllowanceUnlimited -> -1
+    PrivateRepoAllowanceLimited n -> fromIntegral n
+
+instance FromJSON PrivateRepoAllowance where
+    parseJSON v = fromNumeric <$> parseJSON v
+
+instance ToJSON PrivateRepoAllowance where
+    toJSON = toJSON . toNumeric
+    toEncoding = toEncoding . toNumeric
+
+instance PersistField PrivateRepoAllowance where
+    toPersistValue = toPersistValue . toNumeric
+    fromPersistValue v = fromNumeric <$> fromPersistValue v
+
+instance PersistFieldSql PrivateRepoAllowance where
+    sqlType _ = sqlType @Int undefined

--- a/src/Restyled/PrivateRepoEnabled.hs
+++ b/src/Restyled/PrivateRepoEnabled.hs
@@ -1,0 +1,98 @@
+module Restyled.PrivateRepoEnabled
+    ( PrivateRepoEnabled(..)
+    , enableMarketplaceRepo
+    , enableMarketplaceRepoForUser
+    , disableMarketplaceRepoForUser
+    )
+where
+
+import Restyled.Prelude
+
+import Data.List (genericLength)
+import Restyled.Models
+import Restyled.PrivateRepoAllowance
+
+data PrivateRepoEnabled
+    = PrivateRepoEnabled
+    | PrivateRepoNotAllowed
+    | PrivateRepoLimited
+
+enableMarketplaceRepo
+    :: MonadIO m => Entity Repo -> SqlPersistT m (Maybe PrivateRepoEnabled)
+enableMarketplaceRepo (Entity repoId repo) = runMaybeT $ do
+    account <- fetchMarketplaceAccountForRepoT repo
+    enableMarketplaceRepoIdForAccountT repoId account
+
+enableMarketplaceRepoForUser
+    :: MonadIO m
+    => Entity Repo
+    -> Entity User
+    -> SqlPersistT m (Maybe PrivateRepoEnabled)
+enableMarketplaceRepoForUser repo@(Entity repoId _) user = runMaybeT $ do
+    account <- fetchMarketplaceAccountForRepoUserT repo user
+    enableMarketplaceRepoIdForAccountT repoId account
+
+enableMarketplaceRepoIdForAccountT
+    :: MonadIO m
+    => RepoId
+    -> Entity MarketplaceAccount
+    -> MaybeT (SqlPersistT m) PrivateRepoEnabled
+enableMarketplaceRepoIdForAccountT repoId (Entity accountId account) = do
+    Entity planId plan <- getEntityT $ marketplaceAccountMarketplacePlan account
+
+    lift
+        $ enableMarketplaceRepoForPlan planId accountId repoId
+        $ marketplacePlanPrivateRepoAllowance plan
+
+enableMarketplaceRepoForPlan
+    :: MonadIO m
+    => MarketplacePlanId
+    -> MarketplaceAccountId
+    -> RepoId
+    -> PrivateRepoAllowance
+    -> SqlPersistT m PrivateRepoEnabled
+enableMarketplaceRepoForPlan planId accountId repoId = \case
+    PrivateRepoAllowanceNone -> pure PrivateRepoNotAllowed
+    PrivateRepoAllowanceUnlimited -> pure PrivateRepoEnabled
+    PrivateRepoAllowanceLimited limit -> do
+        enabledRepoIds <-
+            marketplaceEnabledRepoRepo
+            . entityVal
+            <$$> selectList
+                     [ MarketplaceEnabledRepoMarketplacePlan ==. planId
+                     , MarketplaceEnabledRepoMarketplaceAccount ==. accountId
+                     ]
+                     []
+
+        result <- checkEnabledRepos enabledRepoIds limit
+        pure $ if result then PrivateRepoEnabled else PrivateRepoLimited
+  where
+    checkEnabledRepos enabledRepoIds limit
+        | repoId `elem` enabledRepoIds = pure True
+        | genericLength enabledRepoIds >= limit = pure False
+        | otherwise = True <$ insert MarketplaceEnabledRepo
+            { marketplaceEnabledRepoMarketplacePlan = planId
+            , marketplaceEnabledRepoMarketplaceAccount = accountId
+            , marketplaceEnabledRepoRepo = repoId
+            }
+
+disableMarketplaceRepoForUser
+    :: MonadIO m => Entity Repo -> Entity User -> SqlPersistT m ()
+disableMarketplaceRepoForUser repo user = void $ runMaybeT $ do
+    account <- fetchMarketplaceAccountForRepoUserT repo user
+    plan <- getEntityT $ marketplaceAccountMarketplacePlan $ entityVal account
+    lift $ deleteWhere
+        [ MarketplaceEnabledRepoMarketplacePlan ==. entityKey plan
+        , MarketplaceEnabledRepoMarketplaceAccount ==. entityKey account
+        , MarketplaceEnabledRepoRepo ==. entityKey repo
+        ]
+
+fetchMarketplaceAccountForRepoUserT
+    :: MonadIO m
+    => Entity Repo
+    -> Entity User
+    -> MaybeT (SqlPersistT m) (Entity MarketplaceAccount)
+fetchMarketplaceAccountForRepoUserT repo user = do
+    repoAccount <- fetchMarketplaceAccountForRepoT $ entityVal repo
+    userAccount <- fetchMarketplaceAccountForUserT $ entityVal user
+    userAccount <$ guard (userAccount == repoAccount)

--- a/templates/admin/marketplace.hamlet
+++ b/templates/admin/marketplace.hamlet
@@ -12,6 +12,8 @@
         <div .right>
           $if isPrivateRepoPlan $ entityVal $ mpwaPlan plan
             <i .fas .fa-lock>
-        #{marketplacePlanGithubId $ entityVal $ mpwaPlan plan}:
-        #{marketplacePlanName $ entityVal $ mpwaPlan plan}
+        $maybe x <- marketplacePlanGithubId $ entityVal $ mpwaPlan plan
+          [#{x}] #{marketplacePlanName $ entityVal $ mpwaPlan plan}
+        $nothing
+          #{marketplacePlanName $ entityVal $ mpwaPlan plan}
       ^{accountsList (Just $ mpwaDescription plan) $ mpwaOwnerNames plan}

--- a/templates/profile/github-identity-card.hamlet
+++ b/templates/profile/github-identity-card.hamlet
@@ -2,7 +2,7 @@
   <header>
     <div .right>
       $maybe Entity _ plan <- mdPlan <$> ghiMarketplaceData
-        $if marketplacePlanGithubId plan /= 0
+        $if isJust (marketplacePlanGithubId plan)
           $# edit plan directly in Marketplace
           <a href=https://github.com/marketplace/restyled-io>
             #{marketplacePlanName plan}

--- a/test/Restyled/Test/Factories.hs
+++ b/test/Restyled/Test/Factories.hs
@@ -9,6 +9,7 @@ where
 import Restyled.Prelude
 
 import Restyled.Models
+import Restyled.PrivateRepoAllowance
 
 buildRepo :: OwnerName -> RepoName -> Repo
 buildRepo owner name = Repo
@@ -37,7 +38,8 @@ buildPrivateRepo owner name = Repo
 -- | TODO: this should be Fixture, not Factory because it's a singleton
 buildPrivateMarketplacePlan :: MarketplacePlan
 buildPrivateMarketplacePlan = MarketplacePlan
-    { marketplacePlanGithubId = 2695
+    { marketplacePlanGithubId = Just 2695
+    , marketplacePlanPrivateRepoAllowance = PrivateRepoAllowanceLimited 1
     , marketplacePlanName = "Solo"
     , marketplacePlanDescription = ""
     }


### PR DESCRIPTION
Previously, we had the one special Plan with `github_id=0` to represent our only
non-GitHub Plan. We also had a case statement based on hard-coded `github_id`
values, to decide the private-repo allowance for any given Plan.

As of this patch,

1. `github_id` is `NULL`-able. No Id means non-GitHub
2. `private_repo_allowance` is explicit, on the table itself

This means `github_id` is only used during sync, and not logically within the
application. And we read `private_repo_allowance` to know how to limit things
for a given Plan.

Now, we can create more non-GitHub plans with their own limitations, which we'll
need to do when we get listed in AppSumo.

**NOTE**: `private_repo_allowance` is modeled as a number in the Database, where
negative numbers means Unlimited. This wart is dispatched immediately through
the `PersistField` instance, so it shouldn't be problematic, provided we don't
grow more applications that directly interface with the Database.