### PR TITLE
Disable Restyle Machine if Daemone goes missing

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -44,6 +44,7 @@ library:
   dependencies:
     - aeson
     - aeson-casing
+    - aeson-pretty
     - ansi-terminal
     - blaze-html
     - blaze-markup

--- a/restyled.cabal
+++ b/restyled.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: e216828535fede457603c08e1115259e2f721491e46238695316be6f03d26e88
+-- hash: c71755fa803077437b75116d91da59e7d09c237594ba6da4db37be2bd0316ec2
 
 name:           restyled
 version:        0.1.1.0
@@ -41,6 +41,7 @@ library
       Restyled.Backend.ExecRestyler
       Restyled.Backend.Foundation
       Restyled.Backend.MarketplaceSync
+      Restyled.Backend.MissingDaemonError
       Restyled.Backend.Reconcile
       Restyled.Backend.RestyleMachine
       Restyled.Backend.Webhook
@@ -114,6 +115,7 @@ library
   build-depends:
       aeson
     , aeson-casing
+    , aeson-pretty
     , ansi-terminal
     , base
     , blaze-html

--- a/src/Restyled/Admin/CreateMachine.hs
+++ b/src/Restyled/Admin/CreateMachine.hs
@@ -1,13 +1,16 @@
 module Restyled.Admin.CreateMachine
-    ( createMachinePlaceholder
+    ( createMachineForm
     , createMachineGetRestyleMachine
-    )
-where
+    ) where
 
 import Restyled.Prelude
 
+import Data.Aeson.Encode.Pretty
+import Data.ByteString.Lazy as BSL
 import Restyled.Backend.RestyleMachine
+import Restyled.Foundation
 import Restyled.Models
+import Restyled.Yesod
 
 data CreateMachine = CreateMachine
     { name :: Text
@@ -19,16 +22,34 @@ data CreateMachine = CreateMachine
     deriving stock Generic
     deriving anyclass (FromJSON, ToJSON)
 
-createMachinePlaceholder :: Text
-createMachinePlaceholder = mconcat
-    [ "{"
-    , "\n  \"name\": \"...\","
-    , "\n  \"host\": \"...\","
-    , "\n  \"certificateAuthority\": \"...\","
-    , "\n  \"certificateAuthority\": \"...\","
-    , "\n  \"privateKey\": \"...\","
-    , "\n}"
-    ]
+createMachineForm :: Form (Handler RestyleMachine)
+createMachineForm = renderDivs $ createMachineGetRestyleMachine <$> areq
+    (jsonFieldWith encodeCreateMachine)
+    ("Machine JSON" { fsAttrs = [("rows", "30")] })
+    (Just createMachineExample)
+
+encodeCreateMachine :: CreateMachine -> Text
+encodeCreateMachine = decodeUtf8 . BSL.toStrict . encodePretty' c
+  where
+    c = defConfig
+        { confCompare =
+            keyOrder
+                [ "name"
+                , "host"
+                , "certificateAuthority"
+                , "certificate"
+                , "privateKey"
+                ]
+        }
+
+createMachineExample :: CreateMachine
+createMachineExample = CreateMachine
+    { name = "..."
+    , host = "..."
+    , certificateAuthority = ""
+    , certificate = ""
+    , privateKey = ""
+    }
 
 createMachineGetRestyleMachine
     :: ( MonadUnliftIO m

--- a/src/Restyled/Admin/CreateMachine.hs
+++ b/src/Restyled/Admin/CreateMachine.hs
@@ -24,7 +24,7 @@ data CreateMachine = CreateMachine
 
 createMachineForm :: Form (Handler RestyleMachine)
 createMachineForm = renderDivs $ createMachineGetRestyleMachine <$> areq
-    (jsonFieldWith encodeCreateMachine)
+    (jsonField encodeCreateMachine)
     ("Machine JSON" { fsAttrs = [("rows", "30")] })
     (Just createMachineExample)
 

--- a/src/Restyled/Backend/MissingDaemonError.hs
+++ b/src/Restyled/Backend/MissingDaemonError.hs
@@ -1,0 +1,54 @@
+module Restyled.Backend.MissingDaemonError
+    ( MissingDaemonError(..)
+    , toMissingDaemonError
+    , onMissingDaemonError
+    ) where
+
+import Restyled.Prelude
+
+import Restyled.Backend.RestyleMachine
+
+newtype MissingDaemonError = MissingDaemonError
+    { unMissingDaemonError :: ExitCodeException
+    }
+    deriving stock Show
+    deriving newtype Exception
+
+instance Display MissingDaemonError where
+    display = fromString . displayException
+
+toMissingDaemonError :: ExitCodeException -> Maybe MissingDaemonError
+toMissingDaemonError ex = do
+    guard $ eceExitCode ex == ExitFailure 125
+    pure $ MissingDaemonError ex
+
+onMissingDaemonError
+    :: ( MonadUnliftIO m
+       , MonadReader env m
+       , HasLogFunc env
+       , HasProcessContext env
+       , HasDB env
+       )
+    => MissingDaemonError
+    -> m ExitCode
+onMissingDaemonError ex = runDB $ do
+    lift $ logDebug "MissingDaemonError"
+    mRestyleMachineId <- entityKey <$$> getCurrentRestyleMachine
+
+    lift
+        $ logDebug
+        $ "Current Restyle Machine: "
+        <> maybe "<unknown>" (display . toPathPiece) mRestyleMachineId
+
+    for_ mRestyleMachineId $ \machineId -> do
+        wasDisabled <- disableRestyleMachine machineId
+
+        lift $ logDebug $ "Disabled: " <> displayShow wasDisabled
+        when wasDisabled
+            $ lift
+            $ logWarn
+            $ "Disabled current Restyle Machine ("
+            <> display ex
+            <> ")"
+
+    pure $ ExitFailure 99

--- a/src/Restyled/Backend/RestyleMachine.hs
+++ b/src/Restyled/Backend/RestyleMachine.hs
@@ -12,13 +12,13 @@ import Restyled.Prelude
 
 import qualified Data.Map as Map
 import qualified Data.Text.IO as T
-import Restyled.Models
 import RIO.Directory
     ( createDirectoryIfMissing
     , doesDirectoryExist
     , getHomeDirectory
     , removeDirectoryRecursive
     )
+import Restyled.Models
 import System.FilePath ((</>))
 
 -- | Run a process on a @'RestyleMachine'@s

--- a/src/Restyled/Handlers/Admin/Machines.hs
+++ b/src/Restyled/Handlers/Admin/Machines.hs
@@ -10,8 +10,7 @@ module Restyled.Handlers.Admin.Machines
     , deleteAdminMachineR
     , getAdminMachineInfoR
     , getAdminMachinePruneR
-    )
-where
+    ) where
 
 import Restyled.Prelude
 
@@ -23,15 +22,6 @@ import Restyled.Models
 import Restyled.Settings
 import Restyled.WebSockets
 import Restyled.Yesod
-
-machineForm :: Form (Handler RestyleMachine)
-machineForm =
-    renderDivs
-        $ createMachineGetRestyleMachine
-        <$> areq jsonField "Machine JSON" { fsAttrs = attrs } Nothing
-  where
-    attrs :: [(Text, Text)]
-    attrs = [("placeholder", createMachinePlaceholder), ("rows", "30")]
 
 getAdminMachinesR :: Handler TypedContent
 getAdminMachinesR = do
@@ -46,7 +36,7 @@ getAdminMachinesR = do
 
 getAdminMachinesNewR :: Handler Html
 getAdminMachinesNewR = do
-    (widget, enctype) <- generateFormPost machineForm
+    (widget, enctype) <- generateFormPost createMachineForm
 
     adminLayout $ do
         setTitle "Restyled Admin / New Machine"
@@ -55,7 +45,7 @@ getAdminMachinesNewR = do
 postAdminMachinesR :: Handler TypedContent
 postAdminMachinesR = selectRep $ do
     provideRep @_ @Html $ do
-        ((result, widget), enctype) <- runFormPost machineForm
+        ((result, widget), enctype) <- runFormPost createMachineForm
 
         case result of
             FormSuccess getMachine -> do

--- a/src/Restyled/Yesod.hs
+++ b/src/Restyled/Yesod.hs
@@ -7,7 +7,6 @@ module Restyled.Yesod
 
     -- * Fields
     , jsonField
-    , jsonFieldWith
 
     -- * TypedContent
     , sendResponseCSV
@@ -39,19 +38,10 @@ getEntity404
 getEntity404 k = Entity k <$> get404 k
 
 jsonField
-    :: ( Monad m
-       , RenderMessage (HandlerSite m) FormMessage
-       , FromJSON a
-       , ToJSON a
-       )
-    => Field m a
-jsonField = jsonFieldWith $ decodeUtf8 . encodeStrict
-
-jsonFieldWith
     :: (Monad m, RenderMessage (HandlerSite m) FormMessage, FromJSON a)
     => (a -> Text)
     -> Field m a
-jsonFieldWith enc = Field
+jsonField enc = Field
     { fieldParse = parseHelper parseVal
     , fieldView = \theId name attrs val isReq -> toWidget [hamlet|
 $newline never


### PR DESCRIPTION
Wee see this sometimes, where a Machine just goes away. Nothing is really setup to catch that or take any action, so this adds a check for that exit code (125) and will disable that Machine, provided it's not the only one in the set.

Additionally, an alert now exists in logDNA for daemon connection errors.