### PR TITLE
Re-implement Job logs with CloudWatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: x
+      AWS_SECRET_ACCESS_KEY: x
     services:
       postgres:
         image: postgres

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ db.migrate:
 
 .PHONY: db.seed
 db.seed:
-	./bin/restyled.io-dev seed-db
+	AWS_PROFILE=restyled ./bin/restyled.io-dev seed-db
 
 .PHONY: db.setup
 db.setup: db.create db.migrate
@@ -82,7 +82,7 @@ test:
 
 .PHONY: watch
 watch:
-	stack build \
+	AWS_PROFILE=restyled stack build \
 	  --fast --pedantic --test --file-watch \
 	  --exec bin/restyled-restart \
 	  --ghc-options -DDEVELOPMENT

--- a/package.yaml
+++ b/package.yaml
@@ -46,6 +46,8 @@ library:
     - aeson-casing
     - aeson-pretty
     - ansi-terminal
+    - amazonka
+    - amazonka-cloudwatch-logs
     - blaze-html
     - blaze-markup
     - bytestring

--- a/restyled.cabal
+++ b/restyled.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: d9614f4fba299a10ef4cd27e3bdfbbc781171ed3201eabc902288c7b968c6329
+-- hash: ccfec3cdeaf4ffc6399c40153dfe111c251c412d5981700a0f5cbc9deb3ee6de
 
 name:           restyled
 version:        0.1.1.0
@@ -73,6 +73,7 @@ library
       Restyled.Handlers.System.Metrics
       Restyled.Handlers.Thanks
       Restyled.Handlers.Webhooks
+      Restyled.JobLogLine
       Restyled.Marketplace
       Restyled.Metrics
       Restyled.Models
@@ -100,6 +101,7 @@ library
       Restyled.Widgets.Job
       Restyled.Widgets.JobLogLine
       Restyled.Yesod
+      RIO.AWS
       RIO.DB
       RIO.Logger
       RIO.Process.Follow
@@ -144,6 +146,8 @@ library
       aeson
     , aeson-casing
     , aeson-pretty
+    , amazonka
+    , amazonka-cloudwatch-logs
     , ansi-terminal
     , base
     , blaze-html

--- a/src/RIO/AWS.hs
+++ b/src/RIO/AWS.hs
@@ -1,0 +1,38 @@
+module RIO.AWS
+    ( HasAWS(..)
+    , runAWS
+    , discoverAWS
+    ) where
+
+import RIO
+
+import Control.Monad.Trans.AWS (runResourceT)
+import qualified Control.Monad.Trans.AWS as AWS
+import Yesod.Core.Types (HandlerData)
+import Yesod.Lens
+
+class HasAWS env where
+    awsEnvL :: Lens' env AWS.Env
+
+instance HasAWS AWS.Env where
+    awsEnvL = id
+
+instance HasAWS env => HasAWS (HandlerData child env) where
+    awsEnvL = handlerEnvL . siteL . awsEnvL
+
+runAWS
+    :: (MonadIO m, MonadReader env m, HasAWS env, AWS.AWSRequest a)
+    => a
+    -> m (AWS.Rs a)
+runAWS req = do
+    env <- view awsEnvL
+    liftIO $ runResourceT $ AWS.runAWST env $ AWS.send req
+
+discoverAWS
+    :: MonadIO m
+    => Bool -- ^ Debug?
+    -> m AWS.Env
+discoverAWS debug = do
+    let level = if debug then AWS.Debug else AWS.Info
+    lgr <- AWS.newLogger level stdout
+    liftIO $ AWS.newEnv AWS.Discover <&> AWS.envLogger .~ lgr

--- a/src/Restyled/Backend/Application.hs
+++ b/src/Restyled/Backend/Application.hs
@@ -15,6 +15,7 @@ runWebhooks
        , HasSqlPool env
        , HasRedis env
        , HasProcessContext env
+       , HasAWS env
        )
     => RIO env a
 runWebhooks = forever $ do

--- a/src/Restyled/Backend/DockerRunArgs.hs
+++ b/src/Restyled/Backend/DockerRunArgs.hs
@@ -13,6 +13,12 @@ import Restyled.Settings
 dockerRunArgs :: AppSettings -> AccessToken -> Repo -> Entity Job -> [String]
 dockerRunArgs settings token repo job =
     [ "--net", "user-bridge"
+    , "--log-driver=awslogs"
+    , "--log-opt awslogs-region=us-east-1"
+    , "--log-opt awslogs-group=" <> unpack (appRestylerLogGroup settings)
+    , "--log-opt awslogs-stream="
+        <> unpack (appRestylerLogStreamPrefix settings)
+        <> unpack (toPathPiece $ entityKey job)
     , "--label", "restyler"
     , "--label", "job-id=" <> unpack (toPathPiece $ entityKey job)
     , "--env", "DEBUG=" <> if repoIsDebug settings repo then "1" else ""

--- a/src/Restyled/Backend/DockerRunJob.hs
+++ b/src/Restyled/Backend/DockerRunJob.hs
@@ -1,6 +1,5 @@
 module Restyled.Backend.DockerRunJob
     ( dockerRunJob
-    , followJobContainer
 
     -- * Useful utility
     -- | TODO: find a new home
@@ -11,7 +10,6 @@ import Restyled.Prelude
 
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString.Lazy.Char8 as LBS8
-import Data.Time.ISO8601 (formatISO8601)
 import Restyled.Backend.DockerRunArgs
 import Restyled.Backend.MissingDaemonError
 import Restyled.Models
@@ -21,11 +19,11 @@ import Restyled.Settings
 --
 -- Implementation details:
 --
--- This should behave like @docker run --rm@ in that it runs a container,
--- captures its output, removes it, and returns its exit code. However, we do
--- the steps separately so that, if we die, the container will continue to run
--- and (presumably) complete the restyle. An unremoved container can be found
--- later and reconciled with the open Job state we'd leave in this case.
+-- This should behave like @docker run --rm@ in that it runs a container, waits
+-- for it, removes it, and returns its exit code. However, we do the steps
+-- separately so that, if we die, the container will continue to run and
+-- (presumably) complete the restyle. An unremoved container can be found later
+-- and reconciled with the open Job state we'd leave in this case.
 --
 -- Any exceptions here will be logged and result in exit-code 99. The final
 -- docker-rm is unchecked; it failing is ignored. Reconciliation should clean
@@ -42,79 +40,30 @@ dockerRunJob
     => Entity Repo
     -> Entity Job
     -> m ExitCode
-    -- ^ Exit code will be @99@ if there was some exception in this process
 dockerRunJob (Entity _ repo) job = do
     settings <- view settingsL
     token <- repoInstallationToken settings repo
     handleAny loggedExitFailure
         $ handleJust toMissingDaemonError onMissingDaemonError
-        $ runJobContainer job
-        $ "run"
-        : "--detach"
-        : dockerRunArgs settings token repo job
+        $ dockerRunRm
+        $ dockerRunArgs settings token repo job
 
-runJobContainer
+dockerRunRm
     :: ( MonadUnliftIO m
        , MonadReader env m
        , HasLogFunc env
-       , HasSqlPool env
        , HasProcessContext env
        )
-    => Entity Job
-    -> [String]
+    => [String]
     -> m ExitCode
-runJobContainer job args = do
-    container <- chomp <$> proc "docker" args readProcessStdout_
-
-    -- TODO
-    -- capture job "system"
-    --     $ "Running on "
-    --     <> unpack restyleMachineName
-    --     <> " ("
-    --     <> container
-    --     <> ")"
-
-    followJobContainer Nothing job container
-
-followJobContainer
-    :: ( MonadUnliftIO m
-       , MonadReader env m
-       , HasLogFunc env
-       , HasSqlPool env
-       , HasProcessContext env
-       )
-    => Maybe UTCTime
-    -> Entity Job
-    -> String -- ^ Container Id
-    -> m ExitCode
-followJobContainer mTimestamp job container = do
-    waitAsync <-
-        async
-        $ readExitCode
+dockerRunRm args = do
+    container <-
+        chomp <$> proc "docker" ("run" : "--detach" : args) readProcessStdout_
+    exitCode <-
+        readExitCode
         . chomp
         <$> proc "docker" ["wait", container] readProcessStdout_
-
-    -- If we're reconciling an old Job, capture the logs since we lost it
-    let since = maybe [] (\t -> ["--since", formatISO8601 t]) mTimestamp
-
-    logsAsync <-
-        async
-        $ proc "docker" (["logs", "--follow"] <> since <> [container])
-        $ followProcess (capture job "stdout") (capture job "stderr")
-
-    exitCode <- wait waitAsync <* wait logsAsync
-    capture job "system" $ "Restyler exited " <> displayExitCode exitCode
     exitCode <$ proc "docker" ["rm", container] readProcess
-
-capture
-    :: (MonadUnliftIO m, MonadReader env m, HasLogFunc env, HasSqlPool env)
-    => Entity Job
-    -> Text
-    -> String
-    -> m ()
-capture job stream msg = do
-    when (stream == "system") $ logDebug $ fromString msg
-    runDB $ captureJobLogLine (entityKey job) stream $ pack msg
 
 loggedExitFailure
     :: (MonadIO m, MonadReader env m, HasLogFunc env, Show ex)
@@ -128,11 +77,6 @@ readExitCode s = case readMaybe s of
     Nothing -> ExitFailure 99
     Just 0 -> ExitSuccess
     Just i -> ExitFailure i
-
-displayExitCode :: ExitCode -> String
-displayExitCode = \case
-    ExitSuccess -> "0"
-    ExitFailure i -> show i
 
 chomp :: LBS.ByteString -> String
 chomp = LBS8.unpack . LBS8.reverse . LBS8.dropWhile isSpace . LBS8.reverse

--- a/src/Restyled/Backend/Foundation.hs
+++ b/src/Restyled/Backend/Foundation.hs
@@ -8,6 +8,7 @@ module Restyled.Backend.Foundation
 
 import Restyled.Prelude
 
+import qualified Network.AWS as AWS (Env)
 import Restyled.Settings
 
 -- | Like @'App'@ but with no webapp-related bits
@@ -17,6 +18,7 @@ data Backend = Backend
     , backendProcessContext :: ProcessContext
     , backendConnPool :: ConnectionPool
     , backendRedisConn :: Connection
+    , backendAWSEnv :: AWS.Env
     }
 
 instance HasLogFunc Backend where
@@ -36,6 +38,9 @@ instance HasRedis Backend where
     redisConnectionL =
         lens backendRedisConn $ \x y -> x { backendRedisConn = y }
 
+instance HasAWS Backend where
+    awsEnvL = lens backendAWSEnv $ \x y -> x { backendAWSEnv = y }
+
 loadBackend :: AppSettings -> IO Backend
 loadBackend = loadBackendHandle stdout
 
@@ -50,3 +55,4 @@ loadBackendHandle h settings@AppSettings {..} = do
         <$> mkDefaultProcessContext
         <*> runRIO logFunc createPool
         <*> checkedConnect appRedisConf
+        <*> discoverAWS (appLogLevel == LevelDebug)

--- a/src/Restyled/Backend/Webhook.hs
+++ b/src/Restyled/Backend/Webhook.hs
@@ -37,7 +37,12 @@ data JobNotProcessed
 data JobProcessed = ExecRestylerSuccess (Entity Job) ExitCode
 
 processWebhook
-    :: (HasSettings env, HasLogFunc env, HasProcessContext env, HasSqlPool env)
+    :: ( HasSettings env
+       , HasLogFunc env
+       , HasProcessContext env
+       , HasSqlPool env
+       , HasAWS env
+       )
     => ExecRestyler (RIO env)
     -> ByteString
     -> RIO env ()
@@ -122,7 +127,9 @@ throttleWarn act = do
     delaySeconds = 60
 
 fromNotProcessed
-    :: (HasLogFunc env, HasSqlPool env) => JobNotProcessed -> RIO env ()
+    :: (HasLogFunc env, HasSqlPool env, HasSettings env, HasAWS env)
+    => JobNotProcessed
+    -> RIO env ()
 fromNotProcessed = \case
     WebhookIgnored reason ->
         logDebug $ fromString $ "Webhook ignored: " <> reasonToLogMessage reason

--- a/src/Restyled/Development/Seeds.hs
+++ b/src/Restyled/Development/Seeds.hs
@@ -4,12 +4,16 @@ module Restyled.Development.Seeds
 
 import Restyled.Prelude
 
-import qualified Prelude as Unsafe
+import qualified Data.List.NonEmpty as NE
+import Restyled.JobLogLine
 import Restyled.Marketplace
 import Restyled.Models
 import Restyled.PrivateRepoAllowance
+import Restyled.Settings
 
-seedDB :: MonadIO m => SqlPersistT m ()
+seedDB
+    :: (MonadIO m, MonadReader env m, HasSettings env, HasAWS env)
+    => SqlPersistT m ()
 seedDB = do
     now <- liftIO getCurrentTime
 
@@ -86,12 +90,12 @@ restyledRepoPrivate :: RepoName -> Repo
 restyledRepoPrivate name = (restyledRepo name) { repoIsPrivate = True }
 
 seedJob
-    :: MonadIO m
+    :: (MonadIO m, MonadReader env m, HasSettings env, HasAWS env)
     => Repo
     -> PullRequestNum
     -> UTCTime
     -> Maybe Int
-    -> [(Text, Text)]
+    -> [(JobLogStream, Text)]
     -> SqlPersistT m ()
 seedJob Repo {..} pullRequest createdAt mExitCode untimestamped = do
     -- Start the Job
@@ -105,30 +109,27 @@ seedJob Repo {..} pullRequest createdAt mExitCode untimestamped = do
         , jobCompletedAt = Nothing
         , jobExitCode = Nothing
         , jobLog = Nothing
-        , jobStdout = Nothing
+        , jobStdout = Just "__cw"
         , jobStderr = Nothing
         }
 
     -- Capture it "running"
-    jobLogLines <- for timestamped $ \(t, (stream, content)) -> insertRecord
-        JobLogLine
-            { jobLogLineJob = jobId
-            , jobLogLineCreatedAt = t
-            , jobLogLineStream = stream
-            , jobLogLineContent = content
-            }
+    lift
+        $ captureJobLogLines jobId
+        $ (\(t, (stream, content)) -> jobLogLineAsOf t jobId stream content)
+        <$> timestamped
 
     -- Complete it if appropriate
     for_ mExitCode $ \ec -> do
-        let lastLogLineAt = jobLogLineCreatedAt $ Unsafe.last jobLogLines
+        let lastLogLineAt = fst $ NE.last timestamped
             completedAt = addUTCTime 1 lastLogLineAt
 
-        insert_ JobLogLine
-            { jobLogLineJob = jobId
-            , jobLogLineCreatedAt = completedAt
-            , jobLogLineStream = "system"
-            , jobLogLineContent = "Restyler exited " <> tshow ec
-            }
+        lift
+            $ captureJobLogLines jobId
+            $ pure
+            $ jobLogLineAsOf completedAt jobId JobLogStreamSystem
+            $ "Restyler exited "
+            <> tshow ec
 
         update
             jobId
@@ -138,9 +139,10 @@ seedJob Repo {..} pullRequest createdAt mExitCode untimestamped = do
             ]
   where
     timestamped =
-        zip (secondsFrom createdAt)
-            $ ("system", "docker run --rm ...")
-            : ("system", "Running on ...")
+        NE.fromList
+            $ zip (secondsFrom createdAt)
+            $ (JobLogStreamSystem, "docker run --rm ...")
+            : (JobLogStreamSystem, "Running on ...")
             : untimestamped
 
 secondsFrom :: UTCTime -> [UTCTime]
@@ -148,180 +150,171 @@ secondsFrom t0 = let t1 = addUTCTime 1 t0 in t1 : secondsFrom t1
 
 -- brittany-next-binding --columns=250
 
-restylingOutput :: [(Text, Text)]
+restylingOutput :: [(JobLogStream, Text)]
 restylingOutput =
-    [ ("stderr", "Switched to a new branch 'issue#87'")
-    , ("stdout", "Branch 'issue#87' set up to track remote branch 'issue#87' from 'origin'.")
-    , ("stdout", "Restyling restyled-io/restyler#88")
-    , ("stdout", "Restyled PR does not exist")
-    , ("stderr", "Switched to a new branch 'issue#87-restyled'")
-    , ("stdout", "Restyling \"app/Http/Controllers/Store.php\" via \"php-cs-fixer\"")
-    , ("stderr", "Loaded config default from \"/code/.php_cs\".")
-    , ("stderr", "Paths from configuration file have been overridden by paths provided as command arguments.")
-    , ("stdout", "")
-    , ("stdout", "Fixed all files in 0.010 seconds, 10.000 MB memory used")
-    , ("stdout", "Restyling \"app/Models/Example.php\" via \"php-cs-fixer\"")
+    [ (JobLogStreamStderr, "Switched to a new branch 'issue#87'")
+    , (JobLogStreamStdout, "Branch 'issue#87' set up to track remote branch 'issue#87' from 'origin'.")
+    , (JobLogStreamStdout, "Restyling restyled-io/restyler#88")
+    , (JobLogStreamStdout, "Restyled PR does not exist")
+    , (JobLogStreamStderr, "Switched to a new branch 'issue#87-restyled'")
+    , (JobLogStreamStdout, "Restyling \"app/Http/Controllers/Store.php\" via \"php-cs-fixer\"")
+    , (JobLogStreamStderr, "Loaded config default from \"/code/.php_cs\".")
+    , (JobLogStreamStderr, "Paths from configuration file have been overridden by paths provided as command arguments.")
+    , (JobLogStreamStdout, "Fixed all files in 0.010 seconds, 10.000 MB memory used")
+    , (JobLogStreamStdout, "Restyling \"app/Models/Example.php\" via \"php-cs-fixer\"")
     ]
 
 -- brittany-next-binding --columns=250
 
-noDifferencesOutput :: [(Text, Text)]
+noDifferencesOutput :: [(JobLogStream, Text)]
 noDifferencesOutput =
-    [ ("stdout", "Branch 'lucky/ela-skills-debugger' set up to track remote branch 'lucky/ela-skills-debugger' from 'origin'.")
-    , ("stderr", "Switched to a new branch 'lucky/ela-skills-debugger'")
-    , ("stdout", "Restyling freckle/megarepo#8616")
-    , ("stdout", "Restyled PR does not exist")
-    , ("stderr", "Switched to a new branch 'lucky/ela-skills-debugger-restyled'")
-    , ("stdout", "Setting status of no differences for 686fe0a")
-    , ("stdout", "No style differences found")
+    [ (JobLogStreamStdout, "Branch 'lucky/ela-skills-debugger' set up to track remote branch 'lucky/ela-skills-debugger' from 'origin'.")
+    , (JobLogStreamStderr, "Switched to a new branch 'lucky/ela-skills-debugger'")
+    , (JobLogStreamStdout, "Restyling freckle/megarepo#8616")
+    , (JobLogStreamStdout, "Restyled PR does not exist")
+    , (JobLogStreamStderr, "Switched to a new branch 'lucky/ela-skills-debugger-restyled'")
+    , (JobLogStreamStdout, "Setting status of no differences for 686fe0a")
+    , (JobLogStreamStdout, "No style differences found")
     ]
 
 -- brittany-next-binding --columns=250
 
-invalidArgumentOutput :: [(Text, Text)]
+invalidArgumentOutput :: [(JobLogStream, Text)]
 invalidArgumentOutput =
-    [ ("stderr", "From https://github.com/restyled.io/demo")
-    , ("stderr", " * [new branch]      release/1 -> release/1")
-    , ("stderr", "Switched to a new branch 'trim-fixes'")
-    , ("stdout", "Branch 'trim-fixes' set up to track remote branch 'trim-fixes' from 'origin'.")
-    , ("stdout", "Restyling restyled.io/demo#1")
-    , ("stdout", "Restyled PR does not exist")
-    , ("stderr", "Switched to a new branch 'elevator-trim-fixes-restyled'")
-    , ("stderr", "Process unsuccessful (ExitFailure 127)")
-    , ("stderr", "Command: docker")
-    , ("stderr", "Arguments: [--rm, --net=none, ...]")
-    , ("stderr", "")
-    , ("stderr", "")
-    , ("stderr", "  docker: command not found")
-    , ("stderr", "    1:some/stack")
-    , ("stderr", "    75:trace/there")
-    , ("stderr", "")
-    , ("stderr", "Please see https://google.com")
-    , ("stderr", "")
-    , ("stderr", "Please see")
-    , ("stderr", "")
-    , ("stderr", "  - https://google.com")
-    , ("stderr", "  - https://google.com")
-    , ("stderr", "  - https://google.com")
+    [ (JobLogStreamStderr, "From https://github.com/restyled.io/demo")
+    , (JobLogStreamStderr, " * [new branch]      release/1 -> release/1")
+    , (JobLogStreamStderr, "Switched to a new branch 'trim-fixes'")
+    , (JobLogStreamStdout, "Branch 'trim-fixes' set up to track remote branch 'trim-fixes' from 'origin'.")
+    , (JobLogStreamStdout, "Restyling restyled.io/demo#1")
+    , (JobLogStreamStdout, "Restyled PR does not exist")
+    , (JobLogStreamStderr, "Switched to a new branch 'elevator-trim-fixes-restyled'")
+    , (JobLogStreamStderr, "Process unsuccessful (ExitFailure 127)")
+    , (JobLogStreamStderr, "Command: docker")
+    , (JobLogStreamStderr, "Arguments: [--rm, --net=none, ...]")
+    , (JobLogStreamStderr, "  docker: command not found")
+    , (JobLogStreamStderr, "    1:some/stack")
+    , (JobLogStreamStderr, "    75:trace/there")
+    , (JobLogStreamStderr, "Please see https://google.com")
+    , (JobLogStreamStderr, "Please see")
+    , (JobLogStreamStderr, "  - https://google.com")
+    , (JobLogStreamStderr, "  - https://google.com")
+    , (JobLogStreamStderr, "  - https://google.com")
     ]
 
 -- brittany-next-binding --columns=250
 
-configErrorOutput1 :: [(Text, Text)]
+configErrorOutput1 :: [(JobLogStream, Text)]
 configErrorOutput1 =
-    [ ("stderr", "Switched to a new branch 'fix'")
-    , ("stdout", "Branch 'fix' set up to track remote branch 'fix' from 'origin'.")
-    , ("stderr", "Switched to a new branch 'fix-restyled'")
-    , ("stderr", "We had trouble with your configuration:")
-    , ("stderr", "")
-    , ("stderr", "  Yaml parse exception:")
-    , ("stderr", "  Aeson exception:")
-    , ("stderr", "  Error in $.restylers[2]: - Unexpected key \"prettier\", must be one of")
-    , ("stderr", "  [\"name\",\"image\",\"command\",\"arguments\",\"include\",\"interpreters\",\"supports_arg_sep\",\"supports_multiple_paths\",\"documentation\"].")
-    , ("stderr", "  ")
-    , ("stderr", "  ")
-    , ("stderr", "  Did you intend to specify a full Restyler object, or do you have incorrect")
-    , ("stderr", "  indentation for a named override?")
-    , ("stderr", "  ")
-    , ("stderr", "  Original input:")
-    , ("stderr", "  # Restyler Configuration")
-    , ("stderr", "  #")
-    , ("stderr", "  # Overall notes:")
-    , ("stderr", "  #")
-    , ("stderr", "  # - All keys are optional and default as shown")
-    , ("stderr", "  # - The entire config can also be just a list of values, which will be")
-    , ("stderr", "  #   interpreted as specifying the restylers key")
-    , ("stderr", "  #")
-    , ("stderr", "  ####")
-    , ("stderr", "  ")
-    , ("stderr", "  # Do anything at all?")
-    , ("stderr", "  enabled: true")
-    , ("stderr", "  ")
-    , ("stderr", "  # Push the style fixes directly to the original PR")
-    , ("stderr", "  #")
-    , ("stderr", "  # This setting implies pull_requests: false for origin PRs, and has no effect on")
-    , ("stderr", "  # forked PRs (since we can't push to those).")
-    , ("stderr", "  #")
-    , ("stderr", "  auto: false")
-    , ("stderr", "  ")
-    , ("stderr", "  # Download remote files before restyling")
-    , ("stderr", "  #")
-    , ("stderr", "  # Example:")
-    , ("stderr", "  #")
-    , ("stderr", "  #   remote_files:")
-    , ("stderr", "  #     - url: https://raw.github.com/.../hlint.yaml")
-    , ("stderr", "  #       path: .hlint.yaml")
-    , ("stderr", "  #")
-    , ("stderr", "  # Files must be publicly accessible.")
-    , ("stderr", "  #")
-    , ("stderr", "  remote_files: []")
-    , ("stderr", "  ")
-    , ("stderr", "  # Open Restyle PRs?")
-    , ("stderr", "  pull_requests: true")
-    , ("stderr", "  ")
-    , ("stderr", "  # Leave comments on the original PR linking to the Restyle PR?")
-    , ("stderr", "  comments: true")
-    , ("stderr", "  ")
-    , ("stderr", "  # Set commit statuses on the original PR?")
-    , ("stderr", "  statuses:")
-    , ("stderr", "    # Red status in the case of differences found")
-    , ("stderr", "    differences: true")
-    , ("stderr", "    # Green status in the case of no differences found")
-    , ("stderr", "    no_differences: true")
-    , ("stderr", "    # Red status if we encounter errors restyling")
-    , ("stderr", "    error: true")
-    , ("stderr", "  ")
-    , ("stderr", "  # Request review on the Restyle PR?")
-    , ("stderr", "  #")
-    , ("stderr", "  # Possible values:")
-    , ("stderr", "  #")
-    , ("stderr", "  #   author: From the author of the original PR")
-    , ("stderr", "  #   owner: From the owner of the repository")
-    , ("stderr", "  #")
-    , ("stderr", "  # One value will apply to origin and forked PRs, but you can also specify")
-    , ("stderr", "  # separate values.")
-    , ("stderr", "  #")
-    , ("stderr", "  request_review: none")
-    , ("stderr", "  ")
-    , ("stderr", "  # Add labels to any created Restyle PRs")
-    , ("stderr", "  #")
-    , ("stderr", "  # These can be used to tell other automation to avoid our PRs.")
-    , ("stderr", "  #")
-    , ("stderr", "  labels: []")
-    , ("stderr", "  ")
-    , ("stderr", "  # Which restylers to run")
-    , ("stderr", "  #")
-    , ("stderr", "  # See restyled-io/restylers repository for their defaults.")
-    , ("stderr", "  #")
-    , ("stderr", "  restylers:")
-    , ("stderr", "    - black:")
-    , ("stderr", "        arguments:")
-    , ("stderr", "          - \"--line-length 100\"")
-    , ("stderr", "    - shfmt:")
-    , ("stderr", "        arguments:")
-    , ("stderr", "          - \"-i\"")
-    , ("stderr", "          - \"2\"")
-    , ("stderr", "          - \"-ci\"")
-    , ("stderr", "          - \"-bn\"")
-    , ("stderr", "          - \"-sr\"")
-    , ("stderr", "    - prettier:")
-    , ("stderr", "      include:")
-    , ("stderr", "        - \"**/*.js\"")
-    , ("stderr", "        - \"**/*.jsx\"")
-    , ("stderr", "        - \"**/*.yml\"")
-    , ("stderr", "        - \"**/*.yaml\"")
-    , ("stderr", "        - \"!chats/**/*\"")
-    , ("stderr", "        - \"!flow/**/*\"")
-    , ("stderr", "   ")
-    , ("stderr", "  # Version of the set of Restylers to run")
-    , ("stderr", "  #")
-    , ("stderr", "  # This should correspond to a ref on the restyled-io/restylers repository,")
-    , ("stderr", "  # usually it's a tag that is a date of when that set was released. You could")
-    , ("stderr", "  # re-specific the default in your own config if you prefer to avoid update")
-    , ("stderr", "  # surprises.")
-    , ("stderr", "  #")
-    , ("stderr", "  restylers_version: \"20190715\"")
-    , ("stderr", "")
-    , ("stderr", "Please see https://github.com/restyled-io/restyled.io/wiki/Common-Errors:-.restyled.yaml")
-    , ("stderr", "")
+    [ (JobLogStreamStderr, "Switched to a new branch 'fix'")
+    , (JobLogStreamStdout, "Branch 'fix' set up to track remote branch 'fix' from 'origin'.")
+    , (JobLogStreamStderr, "Switched to a new branch 'fix-restyled'")
+    , (JobLogStreamStderr, "We had trouble with your configuration:")
+    , (JobLogStreamStderr, "  Yaml parse exception:")
+    , (JobLogStreamStderr, "  Aeson exception:")
+    , (JobLogStreamStderr, "  Error in $.restylers[2]: - Unexpected key \"prettier\", must be one of")
+    , (JobLogStreamStderr, "  [\"name\",\"image\",\"command\",\"arguments\",\"include\",\"interpreters\",\"supports_arg_sep\",\"supports_multiple_paths\",\"documentation\"].")
+    , (JobLogStreamStderr, "  ")
+    , (JobLogStreamStderr, "  ")
+    , (JobLogStreamStderr, "  Did you intend to specify a full Restyler object, or do you have incorrect")
+    , (JobLogStreamStderr, "  indentation for a named override?")
+    , (JobLogStreamStderr, "  ")
+    , (JobLogStreamStderr, "  Original input:")
+    , (JobLogStreamStderr, "  # Restyler Configuration")
+    , (JobLogStreamStderr, "  #")
+    , (JobLogStreamStderr, "  # Overall notes:")
+    , (JobLogStreamStderr, "  #")
+    , (JobLogStreamStderr, "  # - All keys are optional and default as shown")
+    , (JobLogStreamStderr, "  # - The entire config can also be just a list of values, which will be")
+    , (JobLogStreamStderr, "  #   interpreted as specifying the restylers key")
+    , (JobLogStreamStderr, "  #")
+    , (JobLogStreamStderr, "  ####")
+    , (JobLogStreamStderr, "  ")
+    , (JobLogStreamStderr, "  # Do anything at all?")
+    , (JobLogStreamStderr, "  enabled: true")
+    , (JobLogStreamStderr, "  ")
+    , (JobLogStreamStderr, "  # Push the style fixes directly to the original PR")
+    , (JobLogStreamStderr, "  #")
+    , (JobLogStreamStderr, "  # This setting implies pull_requests: false for origin PRs, and has no effect on")
+    , (JobLogStreamStderr, "  # forked PRs (since we can't push to those).")
+    , (JobLogStreamStderr, "  #")
+    , (JobLogStreamStderr, "  auto: false")
+    , (JobLogStreamStderr, "  ")
+    , (JobLogStreamStderr, "  # Download remote files before restyling")
+    , (JobLogStreamStderr, "  #")
+    , (JobLogStreamStderr, "  # Example:")
+    , (JobLogStreamStderr, "  #")
+    , (JobLogStreamStderr, "  #   remote_files:")
+    , (JobLogStreamStderr, "  #     - url: https://raw.github.com/.../hlint.yaml")
+    , (JobLogStreamStderr, "  #       path: .hlint.yaml")
+    , (JobLogStreamStderr, "  #")
+    , (JobLogStreamStderr, "  # Files must be publicly accessible.")
+    , (JobLogStreamStderr, "  #")
+    , (JobLogStreamStderr, "  remote_files: []")
+    , (JobLogStreamStderr, "  ")
+    , (JobLogStreamStderr, "  # Open Restyle PRs?")
+    , (JobLogStreamStderr, "  pull_requests: true")
+    , (JobLogStreamStderr, "  ")
+    , (JobLogStreamStderr, "  # Leave comments on the original PR linking to the Restyle PR?")
+    , (JobLogStreamStderr, "  comments: true")
+    , (JobLogStreamStderr, "  ")
+    , (JobLogStreamStderr, "  # Set commit statuses on the original PR?")
+    , (JobLogStreamStderr, "  statuses:")
+    , (JobLogStreamStderr, "    # Red status in the case of differences found")
+    , (JobLogStreamStderr, "    differences: true")
+    , (JobLogStreamStderr, "    # Green status in the case of no differences found")
+    , (JobLogStreamStderr, "    no_differences: true")
+    , (JobLogStreamStderr, "    # Red status if we encounter errors restyling")
+    , (JobLogStreamStderr, "    error: true")
+    , (JobLogStreamStderr, "  ")
+    , (JobLogStreamStderr, "  # Request review on the Restyle PR?")
+    , (JobLogStreamStderr, "  #")
+    , (JobLogStreamStderr, "  # Possible values:")
+    , (JobLogStreamStderr, "  #")
+    , (JobLogStreamStderr, "  #   author: From the author of the original PR")
+    , (JobLogStreamStderr, "  #   owner: From the owner of the repository")
+    , (JobLogStreamStderr, "  #")
+    , (JobLogStreamStderr, "  # One value will apply to origin and forked PRs, but you can also specify")
+    , (JobLogStreamStderr, "  # separate values.")
+    , (JobLogStreamStderr, "  #")
+    , (JobLogStreamStderr, "  request_review: none")
+    , (JobLogStreamStderr, "  ")
+    , (JobLogStreamStderr, "  # Add labels to any created Restyle PRs")
+    , (JobLogStreamStderr, "  #")
+    , (JobLogStreamStderr, "  # These can be used to tell other automation to avoid our PRs.")
+    , (JobLogStreamStderr, "  #")
+    , (JobLogStreamStderr, "  labels: []")
+    , (JobLogStreamStderr, "  ")
+    , (JobLogStreamStderr, "  # Which restylers to run")
+    , (JobLogStreamStderr, "  #")
+    , (JobLogStreamStderr, "  # See restyled-io/restylers repository for their defaults.")
+    , (JobLogStreamStderr, "  #")
+    , (JobLogStreamStderr, "  restylers:")
+    , (JobLogStreamStderr, "    - black:")
+    , (JobLogStreamStderr, "        arguments:")
+    , (JobLogStreamStderr, "          - \"--line-length 100\"")
+    , (JobLogStreamStderr, "    - shfmt:")
+    , (JobLogStreamStderr, "        arguments:")
+    , (JobLogStreamStderr, "          - \"-i\"")
+    , (JobLogStreamStderr, "          - \"2\"")
+    , (JobLogStreamStderr, "          - \"-ci\"")
+    , (JobLogStreamStderr, "          - \"-bn\"")
+    , (JobLogStreamStderr, "          - \"-sr\"")
+    , (JobLogStreamStderr, "    - prettier:")
+    , (JobLogStreamStderr, "      include:")
+    , (JobLogStreamStderr, "        - \"**/*.js\"")
+    , (JobLogStreamStderr, "        - \"**/*.jsx\"")
+    , (JobLogStreamStderr, "        - \"**/*.yml\"")
+    , (JobLogStreamStderr, "        - \"**/*.yaml\"")
+    , (JobLogStreamStderr, "        - \"!chats/**/*\"")
+    , (JobLogStreamStderr, "        - \"!flow/**/*\"")
+    , (JobLogStreamStderr, "   ")
+    , (JobLogStreamStderr, "  # Version of the set of Restylers to run")
+    , (JobLogStreamStderr, "  #")
+    , (JobLogStreamStderr, "  # This should correspond to a ref on the restyled-io/restylers repository,")
+    , (JobLogStreamStderr, "  # usually it's a tag that is a date of when that set was released. You could")
+    , (JobLogStreamStderr, "  # re-specific the default in your own config if you prefer to avoid update")
+    , (JobLogStreamStderr, "  # surprises.")
+    , (JobLogStreamStderr, "  #")
+    , (JobLogStreamStderr, "  restylers_version: \"20190715\"")
+    , (JobLogStreamStderr, "Please see https://github.com/restyled-io/restyled.io/wiki/Common-Errors:-.restyled.yaml")
     ]

--- a/src/Restyled/Foundation.hs
+++ b/src/Restyled/Foundation.hs
@@ -49,6 +49,9 @@ instance HasSqlPool App where
 instance HasRedis App where
     redisConnectionL = backendL . redisConnectionL
 
+instance HasAWS App where
+    awsEnvL = backendL . awsEnvL
+
 loadApp :: Backend -> IO App
 loadApp backend@Backend {..} = App backend
     <$> makeStatic (appStaticDir backendSettings)

--- a/src/Restyled/Handlers/Repos.hs
+++ b/src/Restyled/Handlers/Repos.hs
@@ -13,6 +13,7 @@ import Restyled.Prelude
 
 import qualified Data.Text as T
 import Restyled.Foundation
+import Restyled.JobLogLine
 import Restyled.Models
 import Restyled.Settings
 import Restyled.StreamJobLogLines
@@ -60,9 +61,9 @@ getRepoJobR owner name jobId = do
 
 getRepoJobLogLinesR :: OwnerName -> RepoName -> JobId -> Handler Text
 getRepoJobLogLinesR _owner _name jobId = do
-    job <- runDB $ getEntity404 jobId
+    void $ runDB $ getEntity404 jobId
     webSockets $ streamJobLogLines jobId
 
     -- If not accessed via WebSockets, respond with plain text Job log
-    jobLogLines <- runDB $ entityVal <$$> fetchJobLog job
+    jobLogLines <- fetchJobLogLines jobId
     pure $ T.unlines $ map textJobLogLine jobLogLines

--- a/src/Restyled/JobLogLine.hs
+++ b/src/Restyled/JobLogLine.hs
@@ -1,0 +1,190 @@
+module Restyled.JobLogLine
+    ( JobLogLine(..)
+    , jobLogLine
+    , jobLogLineAsOf
+    , JobLogStream(..)
+    , jobLogStreamToText
+    , fetchJobLogLines
+    , fetchJobLogLinesSince
+    , captureJobLogLine
+    , captureJobLogLines
+    ) where
+
+import Restyled.Prelude
+
+import Control.Lens ((?~))
+import Data.List (find)
+import Data.Time.Clock.POSIX (posixSecondsToUTCTime, utcTimeToPOSIXSeconds)
+import Network.AWS.CloudWatchLogs.CreateLogStream
+import Network.AWS.CloudWatchLogs.DescribeLogGroups
+import Network.AWS.CloudWatchLogs.DescribeLogStreams
+import Network.AWS.CloudWatchLogs.GetLogEvents
+import Network.AWS.CloudWatchLogs.PutLogEvents
+import Network.AWS.CloudWatchLogs.Types
+import Restyled.Models.DB (JobId, JobLogLine(..))
+import Restyled.Settings
+
+jobLogLine :: MonadIO m => JobId -> JobLogStream -> Text -> m JobLogLine
+jobLogLine jobId stream content = do
+    now <- liftIO getCurrentTime
+    pure $ jobLogLineAsOf now jobId stream content
+
+jobLogLineAsOf :: UTCTime -> JobId -> JobLogStream -> Text -> JobLogLine
+jobLogLineAsOf now jobId stream content = JobLogLine
+    { jobLogLineCreatedAt = now
+    , jobLogLineStream = jobLogStreamToText stream
+    , jobLogLineContent = content
+    , jobLogLineJob = jobId
+    }
+
+data JobLogStream
+    = JobLogStreamSystem
+    | JobLogStreamStdout
+    | JobLogStreamStderr
+
+jobLogStreamToText :: JobLogStream -> Text
+jobLogStreamToText = \case
+    JobLogStreamSystem -> "system"
+    JobLogStreamStdout -> "stdout"
+    JobLogStreamStderr -> "stderr"
+
+fetchJobLogLines
+    :: (MonadUnliftIO m, MonadReader env m, HasSettings env, HasAWS env)
+    => JobId
+    -> m [JobLogLine]
+fetchJobLogLines = fetchJobLogLinesSince Nothing
+
+fetchJobLogLinesSince
+    :: (MonadUnliftIO m, MonadReader env m, HasSettings env, HasAWS env)
+    => Maybe UTCTime
+    -> JobId
+    -> m [JobLogLine]
+fetchJobLogLinesSince mStartTime jobId = handleAny (\_ -> pure []) $ do
+    AppSettings {..} <- view settingsL
+
+    let groupName = appRestylerLogGroup
+        streamName = appRestylerLogStreamPrefix <> toPathPiece jobId
+
+    go [] groupName streamName Nothing
+  where
+    -- We consider "since" to be exclusive, but AWS does not. This means that if
+    -- you naively use timestamp of the last event as input to find events since
+    -- it, you will continually get that event again. We add a ms to avoid this.
+    startMilliseconds = (+ 1) . utcTimeToPOSIXMilliseconds <$> mStartTime
+
+    go acc groupName streamName mNextToken = do
+        resp <-
+            runAWS
+            $ getLogEvents groupName streamName
+            & (gleStartTime .~ startMilliseconds)
+            & (gleStartFromHead ?~ True)
+            & (gleNextToken .~ mNextToken)
+
+        let events = resp ^. glersEvents
+
+        if null events
+            then pure acc
+            else go
+                (acc <> mapMaybe (fromOutputLogEvent jobId) events)
+                groupName
+                streamName
+                (resp ^. glersNextForwardToken)
+
+newtype JobLogError
+    = JobLogErrorGroupDoesNotExist Text
+    deriving stock (Eq, Show)
+
+instance Exception JobLogError where
+    displayException = \case
+        JobLogErrorGroupDoesNotExist name ->
+            "LogGroup does not exist with name: " <> show name
+
+captureJobLogLine
+    :: (MonadIO m, MonadReader env m, HasSettings env, HasAWS env)
+    => JobId
+    -> JobLogStream
+    -> Text
+    -> m ()
+captureJobLogLine jobId stream content = do
+    jobLogLines <- pure <$> jobLogLine jobId stream content
+    captureJobLogLines jobId jobLogLines
+
+captureJobLogLines
+    :: (MonadIO m, MonadReader env m, HasSettings env, HasAWS env)
+    => JobId
+    -> NonEmpty JobLogLine
+    -> m ()
+captureJobLogLines jobId jobLogLines = do
+    AppSettings {..} <- view settingsL
+
+    let groupName = appRestylerLogGroup
+        streamName = appRestylerLogStreamPrefix <> toPathPiece jobId
+        events = toInputLogEvent <$> jobLogLines
+
+    mSequenceToken <- findOrCreateLogStream groupName streamName
+
+    void
+        $ runAWS
+        $ putLogEvents groupName streamName events
+        & (pleSequenceToken .~ mSequenceToken)
+
+toInputLogEvent :: JobLogLine -> InputLogEvent
+toInputLogEvent JobLogLine {..} = inputLogEvent
+    (utcTimeToPOSIXMilliseconds jobLogLineCreatedAt)
+    jobLogLineContent
+
+fromOutputLogEvent :: JobId -> OutputLogEvent -> Maybe JobLogLine
+fromOutputLogEvent jobId event = do
+    message <- event ^. oleMessage
+    timestamp <- event ^. oleTimestamp
+    pure JobLogLine
+        { jobLogLineCreatedAt = posixMillisecondsToUTCTime timestamp
+        , jobLogLineStream = jobLogStreamToText JobLogStreamSystem
+        , jobLogLineContent = message
+        , jobLogLineJob = jobId
+        }
+
+findOrCreateLogStream
+    :: (MonadIO m, MonadReader env m, HasAWS env)
+    => Text -- ^ Group name
+    -> Text -- ^ Stream name
+    -> m (Maybe Text) -- ^ Sequence token if existed
+findOrCreateLogStream group name = do
+    resp <-
+        runAWS
+        $ describeLogStreams group
+        & (dlssLogStreamNamePrefix ?~ name)
+        & (dlssLimit ?~ 1)
+
+    let
+        mStream = find
+            ((== Just name) . (^. lsLogStreamName))
+            (resp ^. dlsrsLogStreams)
+
+    case mStream of
+        Nothing -> do
+            assertLogGroupExists group
+            Nothing <$ runAWS (createLogStream group name)
+        Just stream -> pure $ stream ^. lsUploadSequenceToken
+
+assertLogGroupExists
+    :: (MonadIO m, MonadReader env m, HasAWS env) => Text -> m ()
+assertLogGroupExists desiredName = do
+    resp <-
+        runAWS
+        $ describeLogGroups
+        & (dlgLogGroupNamePrefix ?~ desiredName)
+        & (dlgLimit ?~ 1)
+
+    let
+        groupExists = isJust $ find
+            ((== Just desiredName) . (^. lgLogGroupName))
+            (resp ^. dlgrsLogGroups)
+
+    unless groupExists $ throwIO $ JobLogErrorGroupDoesNotExist desiredName
+
+utcTimeToPOSIXMilliseconds :: Integral n => UTCTime -> n
+utcTimeToPOSIXMilliseconds = round . (* 1000) . utcTimeToPOSIXSeconds
+
+posixMillisecondsToUTCTime :: Integral n => n -> UTCTime
+posixMillisecondsToUTCTime = posixSecondsToUTCTime . (/ 1000) . fromIntegral

--- a/src/Restyled/Prelude.hs
+++ b/src/Restyled/Prelude.hs
@@ -59,6 +59,7 @@ import Data.Text as X (pack, unpack)
 import Database.Persist as X
 import Database.Persist.JSONB as X
 import Database.Persist.Sql as X (SqlBackend)
+import RIO.AWS as X
 import RIO.DB as X
 import RIO.List as X (headMaybe, partition)
 import RIO.Logger as X

--- a/src/Restyled/Settings.hs
+++ b/src/Restyled/Settings.hs
@@ -73,6 +73,8 @@ data AppSettings = AppSettings
     , appRestyleMachineLocal :: Bool
     , appRestyleMachineJobsMax :: Natural
     , appRequestTimeout :: Int
+    , appRestylerLogGroup :: Text
+    , appRestylerLogStreamPrefix :: Text
     }
 
 class HasSettings env where
@@ -133,6 +135,8 @@ loadSettings =
         <*> switch "RESTYLE_MACHINE_LOCAL" mempty
         <*> var auto "RESTYLE_MACHINE_JOBS_MAX" (def 3)
         <*> var auto "REQUEST_TIMEOUT" (def 20)
+        <*> var nonempty "RESTYLER_LOG_GROUP" (def "restyled/dev/restyler")
+        <*> var nonempty "RESTYLER_LOG_STREAM_PREFIX" (def "jobs/")
 
 defaultDatabaseURL :: ByteString
 defaultDatabaseURL = "postgres://postgres:password@localhost:5432/restyled"

--- a/src/Restyled/StreamJobLogLines.hs
+++ b/src/Restyled/StreamJobLogLines.hs
@@ -4,33 +4,55 @@ module Restyled.StreamJobLogLines
 
 import Restyled.Prelude
 
+import qualified Data.List.NonEmpty as NE
 import Restyled.Foundation
+import Restyled.JobLogLine
 import Restyled.Models
 import Restyled.WebSockets
 import Restyled.Widgets.JobLogLine
 
 streamJobLogLines :: JobId -> WebSocketsT Handler ()
-streamJobLogLines jobId = ignoringConnectionException $ go 0
+streamJobLogLines jobId = ignoringConnectionException $ go Nothing 0
   where
-    go offset = do
+    go mSince lastBackoff = do
         -- Pre-emptively make sure someone is listening. If we don't do this,
         -- the case of empty log-lines will recurse indefinitely even if the
         -- client has closed their tab
         void $ sendTextDataAck @_ @Text ""
 
-        (isInProgress, logLines) <-
-            lift
-            $ runDB
-            $ (,)
-            <$> fetchJobIsInProgress jobId
-            <*> fetchJobLogLines jobId offset
+        isInProgress <- lift $ runDB $ fetchJobIsInProgress jobId
+        jobLogLines <- lift $ fetchJobLogLinesSince mSince jobId
 
-        htmls <- traverse (lift . renderJobLogLine . entityVal) logLines
+        -- If we got no output, increase the last backoff by 1 (5 max). Reset it
+        -- whenever we do get output.
+        let backoff = if null jobLogLines then min 5 (lastBackoff + 1) else 0
+            mLastCreatedAt =
+                jobLogLineCreatedAt . NE.last <$> NE.nonEmpty jobLogLines
+            mNextSince = mLastCreatedAt <|> mSince
+
+        logDebugN
+            $ "Fetched Job Log"
+            <> "\n  in-progress="
+            <> tshow isInProgress
+            <> "\n  log-lines="
+            <> tshow (map jobLogLineCreatedAt jobLogLines)
+            <> "\n  since="
+            <> tshow mSince
+            <> "\n  last-created="
+            <> tshow mLastCreatedAt
+            <> "\n  next-since="
+            <> tshow mNextSince
+            <> "\n  backoff="
+            <> tshow backoff
+
+        htmls <- traverse (lift . renderJobLogLine) jobLogLines
         void $ sendTextDataAck $ mconcat htmls
 
         -- Always recurse if in progress or we're still streaming lines
-        if isInProgress || not (null logLines)
-            then go $ offset + length logLines
+        if isInProgress || not (null jobLogLines)
+            then do
+                threadDelay $ backoff * 1000000
+                go mNextSince backoff
             else do
                 logDebugN "Closing websocket: Job not in progress"
                 sendClose @_ @Text "Job finished"

--- a/templates/widgets/log-line.hamlet
+++ b/templates/widgets/log-line.hamlet
@@ -1,5 +1,5 @@
 $newline never
 <div .log-line .stream-#{stream}>
-  <span .prefix>#{stream}
+  $# <span .prefix>#{stream}
   <span .level-#{level} .content>
     ^{renderWithURLs message}

--- a/test/Restyled/Models/UserSpec.hs
+++ b/test/Restyled/Models/UserSpec.hs
@@ -87,6 +87,8 @@ emptySettings = AppSettings
     , appRestyleMachineLocal = True
     , appRestyleMachineJobsMax = 3
     , appRequestTimeout = 30
+    , appRestylerLogGroup = ""
+    , appRestylerLogStreamPrefix = ""
     }
 
 userWithEmail :: Text -> User


### PR DESCRIPTION
This will:

- Remove the only thing that taxes the DB at all, possible unlocking moving to a
  tiny instance on AWS.

- Allow containers to be fully fire-and-forget, and not need reconciliation of
  their output. This will unlock moving the processing directly to agents (once
  we have API for Job creation/updates from them).