### PR TITLE
Hide stdout/err from cancel-job

### DIFF
--- a/src/Restyled/Backend/Container.hs
+++ b/src/Restyled/Backend/Container.hs
@@ -8,6 +8,7 @@ module Restyled.Backend.Container
 
 import Restyled.Prelude
 
+import Control.Lens (_1)
 import qualified Data.ByteString.Lazy.Char8 as LBS8
 import Restyled.Models
 
@@ -157,4 +158,8 @@ signalContainer
     -> RunningContainer
     -> m ExitCode
 signalContainer signal RunningContainer {..} =
-    proc "docker" ["kill", "--signal", signal, rcContainerId] runProcess
+    view _1
+        <$> proc
+                "docker"
+                ["kill", "--signal", signal, rcContainerId]
+                readProcess


### PR DESCRIPTION
If successful it reports the container-id, we don't need to see that. If
unsuccessful it (usually) reports container-not-found, and we don't need to see
that either.