### PR TITLE
Pre-factor for Jobs with CloudWatch logging

### DIFF
--- a/restyled.cabal
+++ b/restyled.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 3fc9cabf154a549603c93207c4e4f0af76430c5a4a9ac0ef98644b496405b351
+-- hash: ba26595ef44d0ce9aa35b4fb879dc7fd27d0ff1491564efee5c04a6cb4261f7f
 
 name:           restyled
 version:        0.1.1.0
@@ -84,6 +84,7 @@ library
       Restyled.Models
       Restyled.Models.DB
       Restyled.Models.Job
+      Restyled.Models.JobLogLine
       Restyled.Models.Repo
       Restyled.Models.User
       Restyled.Offers

--- a/src/Restyled/Models/JobLogLine.hs
+++ b/src/Restyled/Models/JobLogLine.hs
@@ -1,0 +1,15 @@
+module Restyled.Models.JobLogLine
+    ( fetchJobLogLines
+    ) where
+
+import Restyled.Prelude
+
+import Restyled.Models.DB
+
+fetchJobLogLines
+    :: MonadIO m => JobId -> Maybe UTCTime -> SqlPersistT m [Entity JobLogLine]
+fetchJobLogLines jobId mSince = selectList
+    (catMaybes
+        [Just (JobLogLineJob ==. jobId), (JobLogLineCreatedAt >.) <$> mSince]
+    )
+    [Asc JobLogLineCreatedAt]

--- a/src/Restyled/StreamJobLogLines.hs
+++ b/src/Restyled/StreamJobLogLines.hs
@@ -4,33 +4,43 @@ module Restyled.StreamJobLogLines
 
 import Restyled.Prelude
 
+import Data.List.NonEmpty as NE
 import Restyled.Foundation
 import Restyled.Models
 import Restyled.WebSockets
 import Restyled.Widgets.JobLogLine
 
-streamJobLogLines :: JobId -> WebSocketsT Handler ()
-streamJobLogLines jobId = ignoringConnectionException $ go 0
+streamJobLogLines :: Entity Job -> WebSocketsT Handler ()
+streamJobLogLines job = ignoringConnectionException $ go 0 Nothing
   where
-    go offset = do
+    go lastBackoff mSince = do
         -- Pre-emptively make sure someone is listening. If we don't do this,
         -- the case of empty log-lines will recurse indefinitely even if the
         -- client has closed their tab
         void $ sendTextDataAck @_ @Text ""
 
-        (isInProgress, logLines) <-
-            lift
-            $ runDB
-            $ (,)
-            <$> fetchJobIsInProgress jobId
-            <*> fetchJobLogLines jobId offset
+        (isInProgress, logLines) <- do
+            output <- lift $ runDB $ fetchJobOutput job mSince
 
-        htmls <- traverse (lift . renderJobLogLine . entityVal) logLines
+            case output of
+                JobOutputInProgress _ logLines -> pure (True, logLines)
+                JobOutputCompleted logLines -> pure (False, logLines)
+                JobOutputCompressed{} -> pure (False, []) -- Legacy
+
+        htmls <- traverse (lift . renderJobLogLine) logLines
         void $ sendTextDataAck $ mconcat htmls
+
+        -- If no lines, backoff more, up to a maximum of 5s; otherwise, reset
+        let backoff = if null logLines then min 5 (lastBackoff + 1) else 0
 
         -- Always recurse if in progress or we're still streaming lines
         if isInProgress || not (null logLines)
-            then go $ offset + length logLines
+            then do
+                threadDelay $ backoff * 1000000
+                go backoff $ getLastLineCreatedAt logLines <|> mSince
             else do
                 logDebugN "Closing websocket: Job not in progress"
                 sendClose @_ @Text "Job finished"
+
+getLastLineCreatedAt :: [JobLogLine] -> Maybe UTCTime
+getLastLineCreatedAt = fmap (jobLogLineCreatedAt . NE.last) . NE.nonEmpty

--- a/src/Restyled/Widgets/Job.hs
+++ b/src/Restyled/Widgets/Job.hs
@@ -86,7 +86,7 @@ jobOutput :: JobOutput -> Widget
 jobOutput output = $(widgetFile "widgets/job-output")
   where
     streamElementId = case output of
-        JobOutputInProgress (Entity jobId _) ->
+        JobOutputInProgress (Entity jobId _) _ ->
             "logs-job-id-" <> toPathPiece jobId
         _ -> "unused"
 

--- a/templates/widgets/job-output.hamlet
+++ b/templates/widgets/job-output.hamlet
@@ -1,5 +1,5 @@
 $case output
-  $of JobOutputInProgress (Entity jobId job)
+  $of JobOutputInProgress (Entity jobId job) _
     <pre
       .logs-stream
       ##{streamElementId}


### PR DESCRIPTION
- Ensure `fetchJobOutput` is the only interface through which we read Job logs,
  making a single spot to read from CloudWatch.
- Ensure we stream logs by `createdAt` (not `offset`), since that will work
  equally well when fetching from CloudWatch.
- Add a small `backoff` when streaming an empty log. This was nice, but note
  required against our own API/DB, but will be necessary when querying AWS APIs.