### PR TITLE
Support Jobs with CloudWatch logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,15 +108,19 @@ jobs:
           heroku_app_name: restyled-io
           dockerfile_name: Dockerfile.web
 
-      - uses: restyled-io/gitops-deploy-action@main
-        with:
-          token: ${{ secrets.GITOPS_ACCESS_TOKEN }}
-          parameter-name: RestyledImage
-          parameter-value: ${{ needs.image.outputs.image }}
-          committer-name: Restyled Commits
-          committer-email: commits@restyled.io
-          repository: restyled-io/ops
-          stacks: cg-app/stacks/*/*/prod/services/*.yaml
+      # Pause deploying Backend services. All efforts are now going into
+      # restyling on Agents directly and removing all Backend from this
+      # repository.
+      #
+      # - uses: restyled-io/gitops-deploy-action@main
+      #   with:
+      #     token: ${{ secrets.GITOPS_ACCESS_TOKEN }}
+      #     parameter-name: RestyledImage
+      #     parameter-value: ${{ needs.image.outputs.image }}
+      #     committer-name: Restyled Commits
+      #     committer-email: commits@restyled.io
+      #     repository: restyled-io/ops
+      #     stacks: cg-app/stacks/*/*/prod/services/*.yaml
 
       - uses: desiderati/github-action-pushover@v1
         if: ${{ always() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: x
+      AWS_SECRET_ACCESS_KEY: x
     services:
       postgres:
         image: postgres

--- a/package.yaml
+++ b/package.yaml
@@ -46,6 +46,9 @@ library:
     - aeson-casing
     - aeson-pretty
     - ansi-terminal
+    - amazonka
+    - amazonka-cloudwatch-logs
+    - amazonka-core
     - blaze-html
     - blaze-markup
     - bytestring

--- a/restyled.cabal
+++ b/restyled.cabal
@@ -79,6 +79,7 @@ library
       Restyled.Handlers.System.Metrics
       Restyled.Handlers.Thanks
       Restyled.Handlers.Webhooks
+      Restyled.JobLogLine
       Restyled.Marketplace
       Restyled.Metrics
       Restyled.Models
@@ -107,6 +108,7 @@ library
       Restyled.Widgets.Job
       Restyled.Widgets.JobLogLine
       Restyled.Yesod
+      RIO.AWS
       RIO.DB
       RIO.Logger
       RIO.Process.Follow
@@ -151,6 +153,9 @@ library
       aeson
     , aeson-casing
     , aeson-pretty
+    , amazonka
+    , amazonka-cloudwatch-logs
+    , amazonka-core
     , ansi-terminal
     , base
     , blaze-html

--- a/src/RIO/AWS.hs
+++ b/src/RIO/AWS.hs
@@ -1,0 +1,44 @@
+module RIO.AWS
+    ( HasAWS(..)
+    , pageAWS
+    , discoverAWS
+    ) where
+
+import RIO
+
+import Conduit
+import qualified Control.Monad.Trans.AWS as AWS
+import Yesod.Core.Types (HandlerData)
+import Yesod.Lens
+
+class HasAWS env where
+    awsEnvL :: Lens' env AWS.Env
+
+instance HasAWS AWS.Env where
+    awsEnvL = id
+
+instance HasAWS env => HasAWS (HandlerData child env) where
+    awsEnvL = handlerEnvL . siteL . awsEnvL
+
+pageAWS
+    :: (MonadIO m, MonadReader env m, HasAWS env, AWS.AWSPager a)
+    => a
+    -> ConduitT (AWS.Rs a) Void (AWS.AWST (ResourceT IO)) r
+    -> m r
+pageAWS req sink = do
+    env <- view awsEnvL
+    liftIO
+        $ runResourceT
+        $ AWS.runAWST env
+        $ runConduit
+        $ AWS.paginate req
+        .| sink
+
+discoverAWS
+    :: MonadIO m
+    => Bool -- ^ Debug?
+    -> m AWS.Env
+discoverAWS debug = do
+    let level = if debug then AWS.Debug else AWS.Info
+    lgr <- AWS.newLogger level stdout
+    liftIO $ AWS.newEnv AWS.Discover <&> AWS.envLogger .~ lgr

--- a/src/Restyled/Api/CreateJob.hs
+++ b/src/Restyled/Api/CreateJob.hs
@@ -12,6 +12,7 @@ import Restyled.Prelude
 import Control.Monad.Validate
 import Restyled.Api.Job (ApiJob, apiJob)
 import Restyled.Models.DB
+import Restyled.Models.Job (markJobAsCloudWatch)
 import Restyled.Settings
 
 data ApiCreateJob = ApiCreateJob
@@ -58,7 +59,7 @@ createJob ApiCreateJob {..} = do
     void $ refuteNothing (repoNotFound owner repo) mRepo
 
     now <- liftIO getCurrentTime
-    job <- lift $ insertEntity Job
+    job <- lift $ insertEntity $ markJobAsCloudWatch $ Job
         { jobSvcs = svcs
         , jobOwner = owner
         , jobRepo = repo

--- a/src/Restyled/Backend/Foundation.hs
+++ b/src/Restyled/Backend/Foundation.hs
@@ -8,6 +8,7 @@ module Restyled.Backend.Foundation
 
 import Restyled.Prelude
 
+import qualified Network.AWS as AWS (Env)
 import Restyled.Settings
 
 -- | Like @'App'@ but with no webapp-related bits
@@ -17,6 +18,7 @@ data Backend = Backend
     , backendProcessContext :: ProcessContext
     , backendConnPool :: ConnectionPool
     , backendRedisConn :: Connection
+    , backendAWSEnv :: AWS.Env
     }
 
 instance HasLogFunc Backend where
@@ -36,6 +38,9 @@ instance HasRedis Backend where
     redisConnectionL =
         lens backendRedisConn $ \x y -> x { backendRedisConn = y }
 
+instance HasAWS Backend where
+    awsEnvL = lens backendAWSEnv $ \x y -> x { backendAWSEnv = y }
+
 loadBackend :: AppSettings -> IO Backend
 loadBackend = loadBackendHandle stdout
 
@@ -50,3 +55,4 @@ loadBackendHandle h settings@AppSettings {..} = do
         <$> mkDefaultProcessContext
         <*> runRIO logFunc createPool
         <*> checkedConnect appRedisConf
+        <*> discoverAWS False -- (appLogLevel == LevelDebug)

--- a/src/Restyled/Foundation.hs
+++ b/src/Restyled/Foundation.hs
@@ -49,6 +49,9 @@ instance HasSqlPool App where
 instance HasRedis App where
     redisConnectionL = backendL . redisConnectionL
 
+instance HasAWS App where
+    awsEnvL = backendL . awsEnvL
+
 loadApp :: Backend -> IO App
 loadApp backend@Backend {..} = App backend
     <$> makeStatic (appStaticDir backendSettings)

--- a/src/Restyled/JobLogLine.hs
+++ b/src/Restyled/JobLogLine.hs
@@ -1,0 +1,99 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Restyled.JobLogLine
+    ( JobLogLine(..)
+    , fetchJobLogLines
+    ) where
+
+import Restyled.Prelude
+
+import Conduit
+import Control.Lens ((?~))
+import Data.Time.Clock.POSIX (posixSecondsToUTCTime, utcTimeToPOSIXSeconds)
+import Network.AWS.CloudWatchLogs.GetLogEvents
+import Network.AWS.CloudWatchLogs.Types
+import Network.AWS.Pager (AWSPager(..))
+import Restyled.Models.DB (JobId, JobLogLine(..))
+import Restyled.Settings
+
+data JobLogStream
+    = JobLogStreamSystem
+    | JobLogStreamStdout
+    | JobLogStreamStderr
+
+jobLogStreamToText :: JobLogStream -> Text
+jobLogStreamToText = \case
+    JobLogStreamSystem -> "system"
+    JobLogStreamStdout -> "stdout"
+    JobLogStreamStderr -> "stderr"
+
+instance AWSPager GetLogEvents where
+    page req resp = do
+        nextToken <- resp ^. glersNextForwardToken
+        let prevToken = req ^. gleNextToken
+        guard $ prevToken /= Just nextToken
+        pure $ req & (gleNextToken ?~ nextToken)
+
+fetchJobLogLines
+    :: ( MonadUnliftIO m
+       , MonadReader env m
+       , HasLogFunc env
+       , HasSettings env
+       , HasAWS env
+       )
+    => JobId
+    -> Maybe UTCTime
+    -> m [JobLogLine]
+fetchJobLogLines jobId mSince = handleAny (errorJobLogLines jobId) $ do
+    AppSettings {..} <- view settingsL
+
+    let groupName = appRestylerLogGroup
+        streamName = appRestylerLogStreamPrefix <> toPathPiece jobId
+        req =
+            getLogEvents groupName streamName
+                & (gleStartTime .~ startMilliseconds)
+                & (gleStartFromHead ?~ True)
+    pageAWS req $ concatMapC (fromGetLogEvents jobId) .| sinkList
+    where startMilliseconds = (+ 1) . utcTimeToPOSIXMilliseconds <$> mSince
+
+errorJobLogLines
+    :: (MonadIO m, MonadReader env m, HasLogFunc env, Show ex)
+    => JobId
+    -> ex
+    -> m [JobLogLine]
+errorJobLogLines jobId ex = do
+    logError
+        $ "Error fetching Job log for Job "
+        <> display (toPathPiece jobId)
+        <> ": "
+        <> displayShow ex
+    now <- liftIO getCurrentTime
+    pure
+        [ JobLogLine
+              { jobLogLineCreatedAt = now
+              , jobLogLineStream = jobLogStreamToText JobLogStreamSystem
+              , jobLogLineContent = "Unable to fetch Job log at this time"
+              , jobLogLineJob = jobId
+              }
+        ]
+
+fromGetLogEvents :: JobId -> GetLogEventsResponse -> [JobLogLine]
+fromGetLogEvents jobId resp =
+    mapMaybe (fromOutputLogEvent jobId) $ resp ^. glersEvents
+
+fromOutputLogEvent :: JobId -> OutputLogEvent -> Maybe JobLogLine
+fromOutputLogEvent jobId event = do
+    message <- event ^. oleMessage
+    timestamp <- event ^. oleTimestamp
+    pure JobLogLine
+        { jobLogLineCreatedAt = posixMillisecondsToUTCTime timestamp
+        , jobLogLineStream = jobLogStreamToText JobLogStreamSystem
+        , jobLogLineContent = message
+        , jobLogLineJob = jobId
+        }
+
+utcTimeToPOSIXMilliseconds :: Integral n => UTCTime -> n
+utcTimeToPOSIXMilliseconds = round . (* 1000) . utcTimeToPOSIXSeconds
+
+posixMillisecondsToUTCTime :: Integral n => n -> UTCTime
+posixMillisecondsToUTCTime = posixSecondsToUTCTime . (/ 1000) . fromIntegral

--- a/src/Restyled/Prelude.hs
+++ b/src/Restyled/Prelude.hs
@@ -59,6 +59,7 @@ import Data.Text as X (pack, unpack)
 import Database.Persist as X
 import Database.Persist.JSONB as X
 import Database.Persist.Sql as X (SqlBackend)
+import RIO.AWS as X
 import RIO.DB as X
 import RIO.List as X (headMaybe, partition)
 import RIO.Logger as X


### PR DESCRIPTION
If a Job exists with the stdout of "__cw", consider that to mark a Job that was
created with logging to CloudWatch. We don't run such job, but the new code in
Agent-based restyling will and this is preparation for prod-testing them.